### PR TITLE
Bugfix/fix gcp bucket filed

### DIFF
--- a/collector/gcp/collector/cloudstorage/bucket.go
+++ b/collector/gcp/collector/cloudstorage/bucket.go
@@ -59,8 +59,8 @@ func GetBucketResource() schema.Resource {
 			return nil
 		},
 		RowField: schema.RowField{
-			ResourceId:   "$.Item.id",
-			ResourceName: "$.Item.name",
+			ResourceId:   "$.Bucket.id",
+			ResourceName: "$.Bucket.name",
 		},
 		Dimension: schema.Global,
 	}


### PR DESCRIPTION
The GCS bucket pushed to channle using a wrong jsonpath to get its `ResourceId` and `ResrouceName`