### PR TITLE
fix: illogic when ruleCode exists but not found in database

### DIFF
--- a/app/application/src/main/java/com/alipay/application/service/rule/domain/repo/RuleRepositoryImpl.java
+++ b/app/application/src/main/java/com/alipay/application/service/rule/domain/repo/RuleRepositoryImpl.java
@@ -208,6 +208,9 @@ public class RuleRepositoryImpl implements RuleRepository {
                 rulePO.setId(existRule.getId());
                 rulePO.setGmtModified(new Date());
                 ruleMapper.updateByPrimaryKeySelective(rulePO);
+            } else {
+                // When RuleCode is not empty,But not exist in database, still should insert
+                ruleMapper.insertSelective(rulePO);
             }
         }
 


### PR DESCRIPTION
<!--
Please keep PRs small and fixed in scope.
Add tests for new features.
-->
Thank you for your contribution to CloudRec!

### What About:
* [x] Server (`java`)
* [ ] Collector (`go`)
* [ ] Rule (`opa`)

### Description:
There was a logic flaw in the `saveOrgRule` method where rules with non-empty `ruleCode` but not existing in the database were being skipped during the insertion process.

### Issue Details
- When `ruleCode` is not empty but no corresponding record exists in the database, the rule should be inserted
- However, the original logic was missing the `else` branch to handle this scenario
- This caused data inconsistency during `initRule` operations where:
  - Rule metadata was not inserted into the main `rule` table
  - But related data (rule types, etc.) were still processed and inserted into associated tables
  - Result: orphaned records in related tables without corresponding main rule records

## Summary by Sourcery

Bug Fixes:
- Ensure rules with a non-empty ruleCode but no existing record are inserted to prevent orphaned related table entries