### PR TITLE
fix: globalVariable upsertData illogic causes false negative in detection

### DIFF
--- a/app/application/src/main/java/com/alipay/application/service/rule/job/RuleScanContext.java
+++ b/app/application/src/main/java/com/alipay/application/service/rule/job/RuleScanContext.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import com.alibaba.fastjson.JSON;
 
 import java.util.List;
 
@@ -81,7 +82,7 @@ public class RuleScanContext {
         opaRepository.createOrUpdatePolicy(ruleAgg.getRegoPath(), ruleAgg.getRegoPolicy());
         if (CollectionUtils.isNotEmpty(ruleAgg.getGlobalVariables())) {
             for (GlobalVariable globalVariable : ruleAgg.getGlobalVariables()) {
-                opaRepository.upsertData(globalVariable.getPath(), globalVariable.getData());
+                opaRepository.upsertData(globalVariable.getPath(), JSON.parse(globalVariable.getData()));
             }
         }
     }


### PR DESCRIPTION
<!--
Please keep PRs small and fixed in scope.
Add tests for new features.
-->
Thank you for your contribution to CloudRec!

### What About:
* [x] Server (`java`)
* [ ] Collector (`go`)
* [ ] Rule (`opa`)

### Description:
This PR fixes a JSON double-encoding issue in the RuleScanContext where global variable data was being incorrectly serialized, causing data corruption. And cause detection failure for rules that rely on global variables during scanByRule and scanByGroup operations

### Issue Details
- globalVariable.getData() returns a JSON string representation of the data
- opaRepository.upsertData() internally serializes the input data to JSON again
- This resulted in double JSON encoding, where the final stored data contained escaped quotes and malformed JSON structure
- Example of the issue:
    - Original data: `{"key": "value"}`
    - After getData(): `"{\"key\": \"value\"}"`
    - After upsertData(): `"\"{\\\"key\\\": \\\"value\\\"}\""` (double-escaped)

## Summary by Sourcery

Bug Fixes:
- Parse the JSON string from globalVariable.getData() before passing it to opaRepository.upsertData to avoid double encoding and ensure correct rule detection