### PR TITLE
fix: resource id would be empty when jsonPath get the wrong way

### DIFF
--- a/collector/aws/collector/ec2/flowlog.go
+++ b/collector/aws/collector/ec2/flowlog.go
@@ -34,8 +34,8 @@ func GetFlowLogResource() schema.Resource {
 		Desc:               "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeFlowLogs.html",
 		ResourceDetailFunc: GetFlowLogDetail,
 		RowField: schema.RowField{
-			ResourceId:   "$.FlowLogId",
-			ResourceName: "$.FlowLogId",
+			ResourceId:   "$.FlowLog.FlowLogId",
+			ResourceName: "$.FlowLog.FlowLogId",
 		},
 		Dimension: schema.Regional,
 	}

--- a/collector/aws/collector/ec2/networkinterface.go
+++ b/collector/aws/collector/ec2/networkinterface.go
@@ -34,8 +34,8 @@ func GetNetworkInterfaceResource() schema.Resource {
 		Desc:               "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNetworkInterfaces.html",
 		ResourceDetailFunc: GetNetworkInterfaceDetail,
 		RowField: schema.RowField{
-			ResourceId:   "$.NetworkInterfaceId",
-			ResourceName: "$.NetworkInterfaceId",
+			ResourceId:   "$.NetworkInterface.NetworkInterfaceId",
+			ResourceName: "$.NetworkInterface.NetworkInterfaceId",
 		},
 		Dimension: schema.Regional,
 	}

--- a/collector/aws/collector/guardduty/detector.go
+++ b/collector/aws/collector/guardduty/detector.go
@@ -36,8 +36,8 @@ func GetDetectorResource() schema.Resource {
 		Desc:               `https://docs.aws.amazon.com/guardduty/latest/APIReference/API_ListDetectors.html`,
 		ResourceDetailFunc: GetDetectorDetail,
 		RowField: schema.RowField{
-			ResourceId:   "$.Detector.DetectorId",
-			ResourceName: "$.Detector.DetectorId", // No friendly name
+			ResourceId:   "$.DetectorId",
+			ResourceName: "$.DetectorId", // No friendly name
 		},
 		Dimension: schema.Regional,
 	}
@@ -45,6 +45,7 @@ func GetDetectorResource() schema.Resource {
 
 // DetectorDetail aggregates all information for a single GuardDuty detector.
 type DetectorDetail struct {
+	DetectorId    string
 	Detector      *guardduty.GetDetectorOutput
 	Administrator *types.Administrator
 	Tags          map[string]string
@@ -76,6 +77,7 @@ func GetDetectorDetail(ctx context.Context, service schema.ServiceInterface, res
 		}
 
 		res <- &DetectorDetail{
+			DetectorId:    detectorId,
 			Detector:      detector,
 			Administrator: administrator,
 			Tags:          tags,

--- a/collector/aws/collector/iam/account_settings.go
+++ b/collector/aws/collector/iam/account_settings.go
@@ -35,8 +35,8 @@ func GetAccountSettingsResource() schema.Resource {
 		Desc:               `https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetAccountSummary.html`,
 		ResourceDetailFunc: GetAccountSettingsDetail,
 		RowField: schema.RowField{
-			ResourceId:   "", // AccountID would be
-			ResourceName: "", // AccountID would be
+			ResourceId:   "$.AccountId", // AccountID would be
+			ResourceName: "$.AccountId", // AccountID would be
 		},
 		Regions:   []string{"ap-northeast-1", "cn-north-1"},
 		Dimension: schema.Regional,
@@ -47,6 +47,8 @@ type AccountSettingsDetail struct {
 	PasswordPolicy types.PasswordPolicy
 
 	AccountSummary map[string]int32
+
+	AccountId string
 
 	// todo
 	//EnabledFeatures []types.FeatureType
@@ -83,6 +85,7 @@ func describeAccountSettingsDetail(ctx context.Context, c *iam.Client) (AccountS
 	return AccountSettingsDetail{
 		PasswordPolicy: passwordPolicy,
 		AccountSummary: accountSummary,
+		AccountId:      log.GetCloudAccountId(ctx),
 	}, nil
 }
 

--- a/collector/aws/collector/opensearch/domain.go
+++ b/collector/aws/collector/opensearch/domain.go
@@ -35,8 +35,8 @@ func GetDomainResource() schema.Resource {
 		Desc:               "https://docs.aws.amazon.com/opensearch-service/latest/APIReference/API_DomainStatus.html",
 		ResourceDetailFunc: GetDomainDetail,
 		RowField: schema.RowField{
-			ResourceId:   "$.Domain.DomainId",
-			ResourceName: "$.Domain.DomainName",
+			ResourceId:   "$.DomainStatus.DomainId",
+			ResourceName: "$.DomainStatus.DomainName",
 		},
 		Dimension: schema.Regional,
 	}

--- a/collector/aws/collector/sqs/queue.go
+++ b/collector/aws/collector/sqs/queue.go
@@ -37,8 +37,8 @@ func GetSQSQueueResource() schema.Resource {
 		Desc:               "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ListQueues.html",
 		ResourceDetailFunc: GetSQSQueueDetail,
 		RowField: schema.RowField{
-			ResourceId:   "$.Queue.QueueUrl",
-			ResourceName: "$.Queue.Name",
+			ResourceId:   "$.Url",
+			ResourceName: "$.Name",
 		},
 		Dimension: schema.Regional,
 	}
@@ -99,7 +99,7 @@ func describeSQSQueueDetail(ctx context.Context, client *sqs.Client, queue SQSQu
 	} else {
 		tags = tagMap
 	}
-	
+
 	queue.Attributes = attributes
 	queue.Policy = policy
 	queue.Tags = tags


### PR DESCRIPTION
<!--
Please keep PRs small and fixed in scope.
Add tests for new features.
-->
Thank you for your contribution to CloudRec!

### What About:
* [ ] Server (`java`)
* [x] Collector (`go`)
* [ ] Rule (`opa`)

### Description:
fix: resource id would be empty when jsonPath get the wrong way

## Summary by Sourcery

Fix resource ID extraction for various AWS collectors by correcting JSONPath expressions and propagating IDs through detail structs

Enhancements:
- Correct JSONPath for ResourceId and ResourceName in AWS collectors (IAM account settings, GuardDuty detectors, SQS queues, EC2 flow logs, network interfaces, and OpenSearch domains)
- Add and populate explicit ID fields (AccountId, DetectorId) in detail structs to ensure resource IDs are not empty