### PR TITLE
fix: unable to access hws ecs

### DIFF
--- a/collector/hws/collector/serivce_for_public_cloud.go
+++ b/collector/hws/collector/serivce_for_public_cloud.go
@@ -46,8 +46,8 @@ import (
 	rdsRegion "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3/region"
 	sfs "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/sfsturbo/v1"
 	sfsRegion "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/sfsturbo/v1/region"
-	vpc "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v2"
-	vpcRegion "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v2/region"
+	vpc "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3"
+	vpcRegion "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/region"
 )
 
 func (s *Services) OBSClient() (*obs.ObsClient, error) {

--- a/collector/hws/collector/service.go
+++ b/collector/hws/collector/service.go
@@ -17,10 +17,11 @@ package collector
 
 import (
 	"context"
-	"github.com/core-sdk/log"
-	"go.uber.org/zap"
 	"net"
 	"time"
+
+	"github.com/core-sdk/log"
+	"go.uber.org/zap"
 
 	"github.com/core-sdk/constant"
 	"github.com/core-sdk/schema"
@@ -41,7 +42,7 @@ import (
 	nat "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/nat/v2"
 	rds "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3"
 	sfs "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/sfsturbo/v1"
-	vpc "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v2"
+	vpc "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3"
 )
 
 func ConfigBaseAuth(ak string, sk string) *basic.Credentials {
@@ -140,6 +141,7 @@ func (s *Services) InitServices(cloudAccountParam schema.CloudAccountParam) (err
 			s.OBS, err = s.OBSClient()
 		case ECS:
 			s.ECS, err = s.ECSClient(param.Region)
+			s.VPC, err = s.VPCClient(param.Region)
 		case IAMUser:
 			s.IAM, err = s.IAMClient()
 		case VPC, SecurityGroup:

--- a/collector/hws/collector/service_for_private_cloud.go
+++ b/collector/hws/collector/service_for_private_cloud.go
@@ -24,7 +24,9 @@ import (
 	eip "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/eip/v2"
 	elb "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/elb/v3"
 	iam "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iam/v3"
-	vpc "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v2"
+
+	// vpc "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v2"
+	vpc "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3"
 )
 
 func ConfigBaseAuthForPrivate(projectId, ak, sk, endpoint string) *basic.Credentials {

--- a/collector/hws/collector/vpc/securitygroup.go
+++ b/collector/hws/collector/vpc/securitygroup.go
@@ -16,12 +16,13 @@
 package vpc
 
 import (
+	"context"
+
+	"github.com/cloudrec/hws/collector"
 	"github.com/core-sdk/constant"
 	"github.com/core-sdk/log"
 	"github.com/core-sdk/schema"
-	"context"
-	"github.com/cloudrec/hws/collector"
-	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v2/model"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model"
 	"go.uber.org/zap"
 )
 

--- a/collector/hws/collector/vpc/vpc.go
+++ b/collector/hws/collector/vpc/vpc.go
@@ -16,12 +16,13 @@
 package vpc
 
 import (
+	"context"
+
+	"github.com/cloudrec/hws/collector"
 	"github.com/core-sdk/constant"
 	"github.com/core-sdk/log"
 	"github.com/core-sdk/schema"
-	"context"
-	"github.com/cloudrec/hws/collector"
-	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v2/model"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model"
 	"go.uber.org/zap"
 )
 

--- a/collector/hws/platform/platform_config.go
+++ b/collector/hws/platform/platform_config.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cloudrec/hws/collector/eip"
 	"github.com/cloudrec/hws/collector/elb"
 	"github.com/cloudrec/hws/collector/evs"
-	"github.com/cloudrec/hws/collector/gaussdb"
+	gaussDB "github.com/cloudrec/hws/collector/gaussdb"
 	"github.com/cloudrec/hws/collector/iam"
 	"github.com/cloudrec/hws/collector/lts"
 	"github.com/cloudrec/hws/collector/nat"


### PR DESCRIPTION
<!--
Please keep PRs small and fixed in scope.
Add tests for new features.
-->
Thank you for your contribution to CloudRec!

### What About:
* [ ] Server (`java`)
* [x] Collector (`go`)
* [ ] Rule (`opa`)

### Description:
This submission is mainly to fix 2 issues:
1. HWS cloud hosts cannot be retrieved due to a null pointer error.
2. Upgrade the VPC SDK from version 2.0 to 3.0, because the old version of the security group API cannot determine whether a security group is set to deny or allow, which is not conducive to writing related detection rules.

## Summary by Sourcery

Fix HWS ECS collection issues and upgrade VPC SDK

Bug Fixes:
- Resolve null pointer when fetching ECS host details

Enhancements:
- Upgrade Huawei VPC SDK from v2 to v3 for proper security group rule support
- Refactor security group retrieval to use SecurityGroupInfo and improve error handling
- Initialize VPC client when setting up ECS service

Chores:
- Update import paths and aliases for vpc/v3 and gaussDB collector modules