### PR TITLE
fix:The number of AWS load balancers does not match the actual count

### DIFF
--- a/collector/aws/collector/services.go
+++ b/collector/aws/collector/services.go
@@ -19,6 +19,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -67,11 +69,11 @@ import (
 	"github.com/aws/smithy-go/logging"
 	"github.com/core-sdk/log"
 	"github.com/core-sdk/schema"
-	"time"
 )
 
 // Services contains regional client of AWS services
 type Services struct {
+	Region string
 	EC2                     *ec2.Client
 	IAM                     *iam.Client
 	S3                      *s3.Client
@@ -173,6 +175,7 @@ func (s *Services) InitServices(cloudAccountParam schema.CloudAccountParam) (err
 		s.ElastiCache = initElastiCacheClient(cfg)
 	case ELB:
 		s.ELB = initELBClient(cfg)
+		s.EC2 = initEC2Client(cfg)
 	case CLB:
 		s.CLB = initCLBClient(cfg)
 	case FSxFileSystem:


### PR DESCRIPTION
<!--
Please keep PRs small and fixed in scope.
Add tests for new features.
-->
Thank you for your contribution to CloudRec!

### What About:
* [ ] Server (`java`)
* [x] Collector (`go`)
* [ ] Rule (`opa`)

### Description:
Fixed the issue of missing counts when retrieving AWS load balancers. The reason was that the original AWS LB retrieval repeatedly created EC2 clients (each LB query would create 2 EC2 clients), causing rate limiting by AWS after a large number of requests, making it impossible to retrieve data for a period of time.

## Summary by Sourcery

Reuse a single EC2 client when retrieving ELB details and increase the DescribeLoadBalancers page size to prevent AWS rate limiting and ensure accurate load balancer counts

Bug Fixes:
- Fix missing AWS load balancer counts caused by rate limiting from repeated EC2 client creation

Enhancements:
- Add PageSize=400 to DescribeLoadBalancers requests
- Include and initialize a shared EC2 client in Services and pass it into ELB detail functions
- Update describeELBDetails to accept the shared EC2 client instead of instantiating new ones per call