### PR TITLE
fix:tencent clb add sg detail fields

### DIFF
--- a/collector/tencent/collector/services.go
+++ b/collector/tencent/collector/services.go
@@ -111,6 +111,10 @@ func (s *Services) InitServices(cloudAccountParam schema.CloudAccountParam) (err
 		if err != nil {
 			log.GetWLogger().Error(fmt.Sprintf("failed to initialize CLB client in region:%s, err:%s", param.Region, err.Error()))
 		}
+		s.VPC, err = createVPCClient(param.Region, s.Credential)
+		if err != nil {
+			log.GetWLogger().Error(fmt.Sprintf("failed to initialize VPC client in region:%s, err:%s", param.Region, err.Error()))
+		}
 	case CDB:
 		s.CDB, err = createCDBClient(param.Region, s.Credential)
 		if err != nil {


### PR DESCRIPTION
<!--
Please keep PRs small and fixed in scope.
Add tests for new features.
-->
Thank you for your contribution to CloudRec!

### What About:
* [ ] Server (`java`)
* [x] Collector (`go`)
* [ ] Rule (`opa`)

### Description:
Tencent Cloud CLB adds `SecurityGroupDetail` field for security groups, as the existing `SecureGroups` field cannot support the inspection of security group rules.

## Summary by Sourcery

Add detailed security group policy retrieval to Tencent CLB collector and include it in load balancer resources

New Features:
- Extend LBDetail with SecurityGroupDetail field to store security group policy sets
- Implement describeSecurityGroups to fetch security group policies via the VPC client

Enhancements:
- Initialize the VPC client in services.go alongside the CLB client
- Update ListCLBResource to use separate CLB and VPC clients and populate the new detail field