### PR TITLE
fix: refactor alicloud fc collector for better data structure

### DIFF
--- a/collector/alicloud/collector/fc/fc.go
+++ b/collector/alicloud/collector/fc/fc.go
@@ -90,7 +90,7 @@ func describeTriggers(ctx context.Context, cli *fc20230330.Client, name *string)
 	request := &fc20230330.ListTriggersRequest{}
 	resp, err := cli.ListTriggers(name, request)
 	if err != nil {
-		log.CtxLogger(ctx).Warn("ListTriggersWithOptions error", zap.Error(err))
+		log.CtxLogger(ctx).Warn("ListTriggers error", zap.Error(err))
 		return nil
 	}
 	triggers = append(triggers, resp.Body.Triggers...)
@@ -99,13 +99,13 @@ func describeTriggers(ctx context.Context, cli *fc20230330.Client, name *string)
 		request.NextToken = resp.Body.NextToken
 		resp, err = cli.ListTriggers(name, request)
 		if err != nil {
-			log.CtxLogger(ctx).Warn("ListTriggersWithOptions error", zap.Error(err))
+			log.CtxLogger(ctx).Warn("ListTriggers error", zap.Error(err))
 			return nil
 		}
 		triggers = append(triggers, resp.Body.Triggers...)
 	}
 
-	return resp.Body.Triggers
+	return triggers
 }
 
 func describeFunction(ctx context.Context, cli *fc20230330.Client) (functions []*fc20230330.Function) {
@@ -129,5 +129,5 @@ func describeFunction(ctx context.Context, cli *fc20230330.Client) (functions []
 		functions = append(functions, result.Body.Functions...)
 	}
 
-	return result.Body.Functions
+	return functions
 }


### PR DESCRIPTION
<!--
Please keep PRs small and fixed in scope.
Add tests for new features.
-->
Thank you for your contribution to CloudRec!

### What About:
* [ ] Server (`java`)
* [x] Collector (`go`)
* [ ] Rule (`opa`)

### Description:
refactor alicloud fc collector for better data structure

## Summary by Sourcery

Refactor the Alicloud FC collector to simplify data structures by modeling resources as individual functions with triggers and full pagination support

Enhancements:
- Update schema row mapping to use function IDs and names
- Emit each function as a separate detail record with associated triggers
- Remove custom domain fields and related logic from the collector
- Introduce a describeTriggers function to fetch function triggers with pagination
- Extend describeFunction to support paginated retrieval of all functions
- Clean up the Detail struct to include only Function and Triggers fields