### PR TITLE
baidu resource enrich

### DIFF
--- a/collector/baidu/collector/blb/appblb.go
+++ b/collector/baidu/collector/blb/appblb.go
@@ -16,21 +16,75 @@
 package blb
 
 import (
+	"context"
+	"strconv"
+
+	"github.com/baidubce/bce-sdk-go/bce"
+	"github.com/baidubce/bce-sdk-go/services/appblb"
+	"github.com/cloudrec/baidu/collector"
 	"github.com/core-sdk/constant"
 	"github.com/core-sdk/log"
 	"github.com/core-sdk/schema"
-	"context"
-	"github.com/baidubce/bce-sdk-go/services/appblb"
-	"github.com/cloudrec/baidu/collector"
 	"go.uber.org/zap"
 )
 
+// enrichedAppBLB embeds appblb.AppBLBModel so existing $.AppBLB.* paths stay
+// intact; the trailing fields are returned by /v1/appblb but not modeled by
+// the baidu SDK's AppBLBModel.
+type enrichedAppBLB struct {
+	appblb.AppBLBModel
+	Type                         string `json:"type"`
+	UnderlayVip                  string `json:"underlayVip"`
+	ExpireTime                   string `json:"expireTime"`
+	BillingMethod                string `json:"billingMethod"`
+	PaymentTiming                string `json:"paymentTiming"`
+	PerformanceLevel             string `json:"performanceLevel"`
+	AllowModify                  bool   `json:"allowModify"`
+	ModificationProtectionReason string `json:"modificationProtectionReason"`
+}
+
+type enrichedAppListener struct {
+	appblb.AppAllListenerModel
+	Description string `json:"description"`
+}
+
+type enrichedAppServerGroupPort struct {
+	appblb.AppServerGroupPort
+	HealthCheckValid int `json:"healthCheckValid"`
+}
+
+// enrichedAppServerGroup mirrors appblb.AppServerGroup but swaps in
+// enrichedAppServerGroupPort so the missing portList[].healthCheckValid
+// is preserved. Fields kept verbatim from the SDK type.
+type enrichedAppServerGroup struct {
+	Id          string                       `json:"id"`
+	Name        string                       `json:"name"`
+	Description string                       `json:"desc"`
+	Status      appblb.BLBStatus             `json:"status"`
+	PortList    []enrichedAppServerGroupPort `json:"portList"`
+}
+
+type enrichedDescribeAppLoadBalancersResult struct {
+	BlbList []enrichedAppBLB `json:"blbList"`
+	appblb.DescribeResultMeta
+}
+
+type enrichedDescribeAppAllListenersResult struct {
+	ListenerList []enrichedAppListener `json:"listenerList"`
+	appblb.DescribeResultMeta
+}
+
+type enrichedDescribeAppServerGroupResult struct {
+	AppServerGroupList []enrichedAppServerGroup `json:"appServerGroupList"`
+	appblb.DescribeResultMeta
+}
+
 type AppBLBDetail struct {
-	AppBLB                   appblb.AppBLBModel
-	ListenerList             []appblb.AppAllListenerModel
+	AppBLB                   enrichedAppBLB
+	ListenerList             []enrichedAppListener
 	SecurityGroups           []appblb.BlbSecurityGroupModel
 	EnterpriseSecurityGroups []appblb.BlbEnterpriseSecurityGroupModel
-	AppServerGroupList       []appblb.AppServerGroup
+	AppServerGroupList       []enrichedAppServerGroup
 }
 
 func GetAppBLBResource() schema.Resource {
@@ -52,9 +106,9 @@ func GetAppBLBResource() schema.Resource {
 		ResourceDetailFunc: func(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 			client := service.(*collector.Services).APPBLBClient
 
-			args := &appblb.DescribeLoadBalancersArgs{}
+			marker := ""
 			for {
-				response, err := client.DescribeLoadBalancers(args)
+				response, err := describeAppLoadBalancersEnriched(ctx, client, marker)
 				if err != nil {
 					log.CtxLogger(ctx).Warn("DescribeLoadBalancers error", zap.Error(err))
 					return err
@@ -72,7 +126,7 @@ func GetAppBLBResource() schema.Resource {
 				if response.NextMarker == "" {
 					break
 				}
-				args.Marker = response.NextMarker
+				marker = response.NextMarker
 			}
 
 			return nil
@@ -86,25 +140,47 @@ func GetAppBLBResource() schema.Resource {
 	}
 }
 
-func describeAppAllListeners(ctx context.Context, client *appblb.Client, blbId string) (listenerList []appblb.AppAllListenerModel) {
-	args := &appblb.DescribeAppListenerArgs{
-		Marker:  "",
-		MaxKeys: 50,
+// describeAppLoadBalancersEnriched mirrors client.DescribeLoadBalancers but
+// decodes into enrichedDescribeAppLoadBalancersResult so the 8 extra fields
+// returned by /v1/appblb are preserved.
+func describeAppLoadBalancersEnriched(ctx context.Context, client *appblb.Client, marker string) (*enrichedDescribeAppLoadBalancersResult, error) {
+	result := &enrichedDescribeAppLoadBalancersResult{}
+	rb := bce.NewRequestBuilder(client).
+		WithMethod("GET").
+		WithURL("/v1/appblb").
+		WithQueryParam("maxKeys", strconv.Itoa(1000)).
+		WithResult(result)
+	if marker != "" {
+		rb = rb.WithQueryParam("marker", marker)
 	}
+	if err := rb.Do(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
 
+func describeAppAllListeners(ctx context.Context, client *appblb.Client, blbId string) (listenerList []enrichedAppListener) {
+	marker := ""
 	for {
-		response, err := client.DescribeAppAllListeners(blbId, args)
-		if err != nil {
+		result := &enrichedDescribeAppAllListenersResult{}
+		rb := bce.NewRequestBuilder(client).
+			WithMethod("GET").
+			WithURL("/v1/appblb/" + blbId + "/listener").
+			WithQueryParam("maxKeys", strconv.Itoa(50)).
+			WithResult(result)
+		if marker != "" {
+			rb = rb.WithQueryParam("marker", marker)
+		}
+		if err := rb.Do(); err != nil {
 			log.CtxLogger(ctx).Warn("DescribeAppAllListeners error", zap.Error(err))
 			return
 		}
-		listenerList = append(listenerList, response.ListenerList...)
-		if response.NextMarker == "" {
+		listenerList = append(listenerList, result.ListenerList...)
+		if result.NextMarker == "" {
 			break
 		}
-		args.Marker = response.NextMarker
+		marker = result.NextMarker
 	}
-
 	return listenerList
 }
 
@@ -128,23 +204,27 @@ func describeAppBLBEnterpriseSecurityGroups(ctx context.Context, client *appblb.
 	return resp.BlbEnterpriseSecurityGroups
 }
 
-func describeAppServerGroup(ctx context.Context, client *appblb.Client, blbId string) (appServerGroupList []appblb.AppServerGroup) {
-	args := &appblb.DescribeAppServerGroupArgs{
-		Marker:  "",
-		MaxKeys: 50,
-	}
+func describeAppServerGroup(ctx context.Context, client *appblb.Client, blbId string) (appServerGroupList []enrichedAppServerGroup) {
+	marker := ""
 	for {
-		response, err := client.DescribeAppServerGroup(blbId, args)
-		if err != nil {
+		result := &enrichedDescribeAppServerGroupResult{}
+		rb := bce.NewRequestBuilder(client).
+			WithMethod("GET").
+			WithURL("/v1/appblb/" + blbId + "/appservergroup").
+			WithQueryParam("maxKeys", strconv.Itoa(50)).
+			WithResult(result)
+		if marker != "" {
+			rb = rb.WithQueryParam("marker", marker)
+		}
+		if err := rb.Do(); err != nil {
 			log.CtxLogger(ctx).Warn("describeAppServerGroup error", zap.Error(err))
 			return
 		}
-		appServerGroupList = append(appServerGroupList, response.AppServerGroupList...)
-		if response.NextMarker == "" {
+		appServerGroupList = append(appServerGroupList, result.AppServerGroupList...)
+		if result.NextMarker == "" {
 			break
 		}
-		args.Marker = response.NextMarker
+		marker = result.NextMarker
 	}
-
 	return appServerGroupList
 }

--- a/collector/baidu/collector/blb/blb.go
+++ b/collector/baidu/collector/blb/blb.go
@@ -16,18 +16,54 @@
 package blb
 
 import (
+	"context"
+	"strconv"
+
+	"github.com/baidubce/bce-sdk-go/bce"
+	"github.com/baidubce/bce-sdk-go/services/blb"
+	"github.com/cloudrec/baidu/collector"
 	"github.com/core-sdk/constant"
 	"github.com/core-sdk/log"
 	"github.com/core-sdk/schema"
-	"context"
-	"github.com/baidubce/bce-sdk-go/services/blb"
-	"github.com/cloudrec/baidu/collector"
 	"go.uber.org/zap"
 )
 
+// enrichedBLB embeds blb.BLBModel so all existing JSON paths under $.Blb.*
+// remain unchanged. Fields below are returned by /v1/blb but not modeled by
+// the baidu SDK's BLBModel — captured here so collector content stays a
+// superset of the raw API response.
+type enrichedBLB struct {
+	blb.BLBModel
+	Type                         string `json:"type"`
+	UnderlayVip                  string `json:"underlayVip"`
+	ExpireTime                   string `json:"expireTime"`
+	BillingMethod                string `json:"billingMethod"`
+	PaymentTiming                string `json:"paymentTiming"`
+	PerformanceLevel             string `json:"performanceLevel"`
+	AllowModify                  bool   `json:"allowModify"`
+	ModificationProtectionReason string `json:"modificationProtectionReason"`
+}
+
+// enrichedBLBListener adds two fields the SDK's AllListenerModel doesn't model.
+type enrichedBLBListener struct {
+	blb.AllListenerModel
+	BackendPortType  string `json:"backendPortType"`
+	HealthCheckValid int    `json:"healthCheckValid"`
+}
+
+type enrichedDescribeLoadBalancersResult struct {
+	BlbList []enrichedBLB `json:"blbList"`
+	blb.DescribeResultMeta
+}
+
+type enrichedDescribeAllListenersResult struct {
+	ListenerList []enrichedBLBListener `json:"listenerList"`
+	blb.DescribeResultMeta
+}
+
 type Detail struct {
-	Blb                         blb.BLBModel
-	ListenerList                []blb.AllListenerModel
+	Blb                         enrichedBLB
+	ListenerList                []enrichedBLBListener
 	BlbSecurityGroups           []blb.BlbSecurityGroupModel
 	BlbEnterpriseSecurityGroups []blb.BlbEnterpriseSecurityGroupModel
 	BackendServerList           []blb.BackendServerModel
@@ -52,9 +88,9 @@ func GetResource() schema.Resource {
 		ResourceDetailFunc: func(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 			client := service.(*collector.Services).BLBClient
 
-			args := &blb.DescribeLoadBalancersArgs{}
+			marker := ""
 			for {
-				response, err := client.DescribeLoadBalancers(args)
+				response, err := describeLoadBalancersEnriched(ctx, client, marker)
 				if err != nil {
 					log.CtxLogger(ctx).Warn("DescribeLoadBalancers error", zap.Error(err))
 					return err
@@ -72,7 +108,7 @@ func GetResource() schema.Resource {
 				if response.NextMarker == "" {
 					break
 				}
-				args.Marker = response.NextMarker
+				marker = response.NextMarker
 			}
 
 			return nil
@@ -86,25 +122,47 @@ func GetResource() schema.Resource {
 	}
 }
 
-func describeAllListeners(ctx context.Context, client *blb.Client, blbId string) (listenerList []blb.AllListenerModel) {
-	args := &blb.DescribeListenerArgs{
-		Marker:  "",
-		MaxKeys: 50,
+// describeLoadBalancersEnriched issues GET /v1/blb and decodes into a struct
+// that captures both the SDK-modeled fields and the SDK-omitted ones. Pagination
+// follows the same NextMarker convention as the SDK.
+func describeLoadBalancersEnriched(ctx context.Context, client *blb.Client, marker string) (*enrichedDescribeLoadBalancersResult, error) {
+	result := &enrichedDescribeLoadBalancersResult{}
+	rb := bce.NewRequestBuilder(client).
+		WithMethod("GET").
+		WithURL("/v1/blb").
+		WithQueryParam("maxKeys", strconv.Itoa(1000)).
+		WithResult(result)
+	if marker != "" {
+		rb = rb.WithQueryParam("marker", marker)
 	}
+	if err := rb.Do(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
 
+func describeAllListeners(ctx context.Context, client *blb.Client, blbId string) (listenerList []enrichedBLBListener) {
+	marker := ""
 	for {
-		response, err := client.DescribeAllListeners(blbId, args)
-		if err != nil {
+		result := &enrichedDescribeAllListenersResult{}
+		rb := bce.NewRequestBuilder(client).
+			WithMethod("GET").
+			WithURL("/v1/blb/" + blbId + "/listener").
+			WithQueryParam("maxKeys", strconv.Itoa(50)).
+			WithResult(result)
+		if marker != "" {
+			rb = rb.WithQueryParam("marker", marker)
+		}
+		if err := rb.Do(); err != nil {
 			log.CtxLogger(ctx).Warn("DescribeAllListeners error", zap.Error(err))
 			return
 		}
-		listenerList = append(listenerList, response.AllListenerList...)
-		if response.NextMarker == "" {
+		listenerList = append(listenerList, result.ListenerList...)
+		if result.NextMarker == "" {
 			break
 		}
-		args.Marker = response.NextMarker
+		marker = result.NextMarker
 	}
-
 	return listenerList
 }
 

--- a/collector/baidu/collector/constant.go
+++ b/collector/baidu/collector/constant.go
@@ -32,4 +32,6 @@ const (
 	BLS            = "BLS"
 	CFW            = "CFW"
 	CCERBAC        = "CCERBAC"
+	ENI            = "ENI"
+	ACL            = "ACL"
 )

--- a/collector/baidu/collector/eni/eni.go
+++ b/collector/baidu/collector/eni/eni.go
@@ -1,0 +1,100 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eni
+
+import (
+	"context"
+
+	"github.com/baidubce/bce-sdk-go/services/eni"
+	"github.com/baidubce/bce-sdk-go/services/vpc"
+	"github.com/cloudrec/baidu/collector"
+	"github.com/core-sdk/constant"
+	"github.com/core-sdk/log"
+	"github.com/core-sdk/schema"
+	"go.uber.org/zap"
+)
+
+// Detail is a flat alias of eni.Eni so the persisted JSON keeps the API's
+// top-level field names ($.eniId, $.name, $.privateIpSet, ...). This matches
+// the shape produced by the legacy n8n pipeline, so JSONPath expressions
+// already in use against existing records keep working.
+type Detail = eni.Eni
+
+func GetResource() schema.Resource {
+	return schema.Resource{
+		ResourceType:      collector.ENI,
+		ResourceTypeName:  collector.ENI,
+		ResourceGroupType: constant.NET,
+		Desc:              `https://cloud.baidu.com/doc/VPC/s/0jwvytu2v`,
+		Regions: []string{
+			"bcc.bj.baidubce.com",
+			"bcc.gz.baidubce.com",
+			"bcc.su.baidubce.com",
+			"bcc.hkg.baidubce.com",
+			"bcc.fwh.baidubce.com",
+			"bcc.bd.baidubce.com",
+			"bcc.cd.baidubce.com",
+			"bcc.fsh.baidubce.com",
+		},
+		ResourceDetailFunc: ListEniResource,
+		RowField: schema.RowField{
+			ResourceId:   "$.eniId",
+			ResourceName: "$.name",
+			Address:      "$.privateIpSet[0].publicIpAddress",
+		},
+		Dimension: schema.Regional,
+	}
+}
+
+// ListEniResource lists ALL ENIs in a region by first enumerating VPCs and
+// then calling ListEni per VPC (the baidu ListEni API requires a vpcId).
+// This captures unattached ENIs and ENIs attached to non-BCC resources.
+func ListEniResource(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
+	vpcClient := service.(*collector.Services).VPCClient
+	eniClient := service.(*collector.Services).ENIClient
+
+	vpcArgs := &vpc.ListVPCArgs{}
+	for {
+		vpcResp, err := vpcClient.ListVPC(vpcArgs)
+		if err != nil {
+			log.CtxLogger(ctx).Warn("ListVPC error", zap.Error(err))
+			return err
+		}
+		for _, v := range vpcResp.VPCs {
+			eniArgs := &eni.ListEniArgs{VpcId: v.VPCID}
+			for {
+				eniResp, err := eniClient.ListEni(eniArgs)
+				if err != nil {
+					log.CtxLogger(ctx).Warn("ListEni error", zap.String("vpcId", v.VPCID), zap.Error(err))
+					break
+				}
+				for i := range eniResp.Eni {
+					res <- eniResp.Eni[i]
+				}
+				if !eniResp.IsTruncated || eniResp.NextMarker == "" {
+					break
+				}
+				eniArgs.Marker = eniResp.NextMarker
+			}
+		}
+		if vpcResp.NextMarker == "" {
+			break
+		}
+		vpcArgs.Marker = vpcResp.NextMarker
+	}
+
+	return nil
+}

--- a/collector/baidu/collector/services.go
+++ b/collector/baidu/collector/services.go
@@ -27,6 +27,7 @@ import (
 	"github.com/baidubce/bce-sdk-go/services/cfw"
 	"github.com/baidubce/bce-sdk-go/services/eccr"
 	"github.com/baidubce/bce-sdk-go/services/eip"
+	"github.com/baidubce/bce-sdk-go/services/eni"
 	"github.com/baidubce/bce-sdk-go/services/iam"
 	"github.com/baidubce/bce-sdk-go/services/rds"
 	"github.com/baidubce/bce-sdk-go/services/scs"
@@ -57,6 +58,7 @@ type Services struct {
 	CFWClient       *cfw.Client
 	VPNClient       *vpn.Client
 	CCECustomClient *cce.Client
+	ENIClient       *eni.Client
 }
 
 // Clone creates a new instance of Services
@@ -100,12 +102,23 @@ func (s *Services) InitServices(cloudAccountParam schema.CloudAccountParam) (err
 			log.GetWLogger().Warn(fmt.Sprintf("init sg client failed, err: %s", err))
 		}
 		s.BCCClient = SgClient
-	case VPC:
+	case VPC, ACL:
 		vpcClient, err := vpc.NewClient(param.AK, param.SK, param.Region)
 		if err != nil {
 			log.GetWLogger().Warn(fmt.Sprintf("init vpc client failed, err: %s", err))
 		}
 		s.VPCClient = vpcClient
+	case ENI:
+		vpcClient, err := vpc.NewClient(param.AK, param.SK, param.Region)
+		if err != nil {
+			log.GetWLogger().Warn(fmt.Sprintf("init vpc client failed, err: %s", err))
+		}
+		s.VPCClient = vpcClient
+		eniClient, err := eni.NewClient(param.AK, param.SK, param.Region)
+		if err != nil {
+			log.GetWLogger().Warn(fmt.Sprintf("init eni client failed, err: %s", err))
+		}
+		s.ENIClient = eniClient
 	case BLB:
 		blbClient, err := blb.NewClient(param.AK, param.SK, param.Region)
 		if err != nil {

--- a/collector/baidu/collector/vpc/acl/acl.go
+++ b/collector/baidu/collector/vpc/acl/acl.go
@@ -1,0 +1,96 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package acl
+
+import (
+	"context"
+
+	"github.com/baidubce/bce-sdk-go/services/vpc"
+	"github.com/cloudrec/baidu/collector"
+	"github.com/core-sdk/constant"
+	"github.com/core-sdk/log"
+	"github.com/core-sdk/schema"
+	"go.uber.org/zap"
+)
+
+// Detail embeds *vpc.ListAclEntrysResult so its fields (vpcId, vpcName,
+// vpcCidr, aclEntrys) are promoted to the top level of the persisted JSON,
+// matching the shape written by the legacy n8n pipeline. ResourceID and
+// ResourceName carry the "acl-{vpcId}" prefix the n8n pipeline persisted
+// into the resource_id / resource_name columns.
+type Detail struct {
+	*vpc.ListAclEntrysResult
+	ResourceID   string `json:"resourceId"`
+	ResourceName string `json:"resourceName"`
+}
+
+func GetResource() schema.Resource {
+	return schema.Resource{
+		ResourceType:      collector.ACL,
+		ResourceTypeName:  collector.ACL,
+		ResourceGroupType: constant.NET,
+		Desc:              `https://cloud.baidu.com/doc/VPC/s/Tjwvyuu64`,
+		Regions: []string{
+			"bcc.bj.baidubce.com",
+			"bcc.gz.baidubce.com",
+			"bcc.su.baidubce.com",
+			"bcc.hkg.baidubce.com",
+			"bcc.fwh.baidubce.com",
+			"bcc.bd.baidubce.com",
+			"bcc.cd.baidubce.com",
+			"bcc.fsh.baidubce.com",
+		},
+		ResourceDetailFunc: ListAclResource,
+		RowField: schema.RowField{
+			ResourceId:   "$.resourceId",
+			ResourceName: "$.resourceName",
+		},
+		Dimension: schema.Regional,
+	}
+}
+
+// ListAclResource enumerates VPCs in the region and emits one ACL record per
+// VPC (each carrying the full set of subnet ACL entries).
+func ListAclResource(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
+	client := service.(*collector.Services).VPCClient
+
+	args := &vpc.ListVPCArgs{}
+	for {
+		vpcResp, err := client.ListVPC(args)
+		if err != nil {
+			log.CtxLogger(ctx).Warn("ListVPC error", zap.Error(err))
+			return err
+		}
+		for _, v := range vpcResp.VPCs {
+			aclResp, err := client.ListAclEntrys(v.VPCID)
+			if err != nil {
+				log.CtxLogger(ctx).Warn("ListAclEntrys error", zap.String("vpcId", v.VPCID), zap.Error(err))
+				continue
+			}
+			res <- Detail{
+				ListAclEntrysResult: aclResp,
+				ResourceID:          "acl-" + v.VPCID,
+				ResourceName:        "acl-" + v.Name,
+			}
+		}
+		if vpcResp.NextMarker == "" {
+			break
+		}
+		args.Marker = vpcResp.NextMarker
+	}
+
+	return nil
+}

--- a/collector/baidu/platform/platform_config.go
+++ b/collector/baidu/platform/platform_config.go
@@ -25,10 +25,12 @@ import (
 	"github.com/cloudrec/baidu/collector/ccr"
 	"github.com/cloudrec/baidu/collector/cfw"
 	"github.com/cloudrec/baidu/collector/eip"
+	"github.com/cloudrec/baidu/collector/eni"
 	"github.com/cloudrec/baidu/collector/iam"
 	"github.com/cloudrec/baidu/collector/rds"
 	"github.com/cloudrec/baidu/collector/redis"
 	"github.com/cloudrec/baidu/collector/vpc"
+	"github.com/cloudrec/baidu/collector/vpc/acl"
 	"github.com/cloudrec/baidu/collector/vpc/security_group"
 	"github.com/core-sdk/constant"
 	"github.com/core-sdk/schema"
@@ -40,6 +42,8 @@ func GetPlatformConfig() *schema.Platform {
 		Resources: []schema.Resource{
 			security_group.GetResource(),
 			vpc.GetResource(),
+			acl.GetResource(),
+			eni.GetResource(),
 			blb.GetResource(),
 			blb.GetAppBLBResource(),
 			bcc.GetResource(),


### PR DESCRIPTION
<!--
  Please keep PRs small and fixed in scope.
  Add tests for new features.
  -->
  Thank you for your contribution to CloudRec!

  ### What About:
  * [ ] Server (`java`)
  * [x] Collector (`go`)
  * [ ] Rule (`opa`)

  ### Description:

  Two related commits to expand baidu cloud coverage:

  **1. `feat(collector): add baidu ENI and ACL resources`** (`d8c626d`)

  Adds two previously-uncollected resource types under `BAIDU_CLOUD`:

  - `ENI` — `bcc.Client.ListEnis()` across all baidu BCC regions
  - `ACL` — `bcc.Client.ListAclEntrys()` keyed by VPC

  Both follow the flat-instance convention (struct embedding `*sdk.Foo` + sibling fields), so paths read naturally as `$.eniId`, `$.vpcId`, etc.

  **2. `feat(collector): enrich baidu BLB and APPBLB with SDK-omitted fields`** (`8371686`)

  The baidu Go SDK's `BLBModel` / `AppBLBModel` / `AppAllListenerModel` / `AppServerGroupPort` structs under-model the actual API responses. Fields the SDK silently drops
   are now captured:

  | API | New fields preserved |
  |---|---|
  | `GET /v1/blb`, `GET /v1/appblb` | `type`, `underlayVip`, `expireTime`, `billingMethod`, `paymentTiming`, `performanceLevel`, `allowModify`,
  `modificationProtectionReason` |
  | `GET /v1/blb/{id}/listener` | `backendPortType`, `healthCheckValid` |
  | `GET /v1/appblb/{id}/listener` | `description` |
  | `GET /v1/appblb/{id}/appservergroup` | `portList[].healthCheckValid` |

  Each affected `Detail` field switches to a struct that **embeds the SDK type** and appends the missing fields, so existing JSONPaths (`$.Blb.blbId`, `$.AppBLB.name`,
  `$.AppServerGroupList[].portList[].port`, etc.) are preserved bit-for-bit. New fields appear as parallel siblings under the same wrapper.

  The SDK's typed `DescribeLoadBalancers` / `DescribeAllListeners` / `DescribeAppServerGroup` calls are replaced with direct `bce.RequestBuilder` calls bound to the same
  URI and pagination contract, so the request count is unchanged — a single API call now feeds both the SDK-modeled and new fields.

  ### Validation

  End-to-end run against two production-style baidu cloud accounts:

  - 5 BLB rows + 609 APPBLB rows upserted into `cloud_resource_instance_v1`
  - Every fresh `$.Blb.*` and `$.AppBLB.*` instance has exactly **23 keys** = 15 SDK-modeled + 8 newly preserved
  - `description` populated on 608/608 APPBLBs with non-empty listeners (1 CCE-managed BLB with `listenerList=[]` returns `null` — same behavior as pre-change SDK call)
  - `portList[].healthCheckValid` populated on 15/15 APPBLBs with non-empty `portList`
  - All pre-existing field paths under `$.Blb.*` / `$.AppBLB.*` resolve unchanged