### PR TITLE
[codex] fix aws elb listener exposure detection

### DIFF
--- a/collector/aws/collector/constant.go
+++ b/collector/aws/collector/constant.go
@@ -29,6 +29,7 @@ const (
 	Vpc                      string = "VPC"
 	CLB                      string = "CLB"
 	ELB                      string = "ELB"
+	ELBListener              string = "ELB Listener"
 	Domain                   string = "Domain"
 	Certificate              string = "Certificate"
 	Secret                   string = "Secret"

--- a/collector/aws/collector/elasticloadbalancing/elasticloadbalancingv2.go
+++ b/collector/aws/collector/elasticloadbalancing/elasticloadbalancingv2.go
@@ -48,14 +48,36 @@ func GetELBResource() schema.Resource {
 	}
 }
 
+func GetELBListenerResource() schema.Resource {
+	return schema.Resource{
+		ResourceType:       collector.ELBListener,
+		ResourceTypeName:   "ELB Listener",
+		ResourceGroupType:  constant.NET,
+		Desc:               `https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeListeners.html`,
+		ResourceDetailFunc: GetELBListenerDetail,
+		RowField: schema.RowField{
+			ResourceId:   "$.Listener.ListenerArn",
+			ResourceName: "$.Listener.ListenerArn",
+		},
+		Dimension: schema.Regional,
+	}
+}
+
 type ELBDetail struct {
 	ELB types.LoadBalancer
+
+	// Listeners information of the LoadBalancer
+	Listeners []types.Listener
 
 	// SecurityGroups information of the LoadBalancer
 	SecurityGroups []ec2.SecurityGroupDetail
 
 	// VPC information of the LoadBalancer
 	VPC []ec2.VPCDetail
+}
+
+type ELBListenerDetail struct {
+	Listener types.Listener
 }
 
 func GetELBDetail(ctx context.Context, iService schema.ServiceInterface, res chan<- any) error {
@@ -75,6 +97,22 @@ func GetELBDetail(ctx context.Context, iService schema.ServiceInterface, res cha
 	return nil
 }
 
+func GetELBListenerDetail(ctx context.Context, iService schema.ServiceInterface, res chan<- any) error {
+	elbClient := iService.(*collector.Services).ELB
+
+	listeners, err := describeELBListeners(ctx, elbClient)
+	if err != nil {
+		log.CtxLogger(ctx).Warn("describeELBListeners error", zap.Error(err))
+		return err
+	}
+
+	for _, listener := range listeners {
+		res <- ELBListenerDetail{Listener: listener}
+	}
+
+	return nil
+}
+
 func describeELBDetails(ctx context.Context, elbClient *elasticloadbalancingv2.Client, ec2Client *ec2_2.Client) (ELBDetails []ELBDetail, err error) {
 	elbs, err := describeELBs(ctx, elbClient)
 	if err != nil {
@@ -82,8 +120,13 @@ func describeELBDetails(ctx context.Context, elbClient *elasticloadbalancingv2.C
 	}
 
 	for _, elb := range elbs {
+		listeners, err := describeELBListenersByLoadBalancerArn(ctx, elbClient, elb.LoadBalancerArn)
+		if err != nil {
+			log.CtxLogger(ctx).Warn("DescribeListeners error", zap.Error(err), zap.String("loadBalancerArn", aws.ToString(elb.LoadBalancerArn)))
+		}
 		ELBDetails = append(ELBDetails, ELBDetail{
-			ELB: elb,
+			ELB:       elb,
+			Listeners: listeners,
 			VPC: ec2.DescribeVPCDetailsByFilters(ctx, ec2Client, []types2.Filter{
 				{
 					Name:   aws.String("vpc-id"),
@@ -99,6 +142,46 @@ func describeELBDetails(ctx context.Context, elbClient *elasticloadbalancingv2.C
 		})
 	}
 	return ELBDetails, nil
+}
+
+func describeELBListeners(ctx context.Context, c *elasticloadbalancingv2.Client) (listeners []types.Listener, err error) {
+	elbs, err := describeELBs(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	for _, elb := range elbs {
+		lbListeners, err := describeELBListenersByLoadBalancerArn(ctx, c, elb.LoadBalancerArn)
+		if err != nil {
+			log.CtxLogger(ctx).Warn("DescribeListeners error", zap.Error(err), zap.String("loadBalancerArn", aws.ToString(elb.LoadBalancerArn)))
+			continue
+		}
+		listeners = append(listeners, lbListeners...)
+	}
+	return listeners, nil
+}
+
+func describeELBListenersByLoadBalancerArn(ctx context.Context, c *elasticloadbalancingv2.Client, loadBalancerArn *string) (listeners []types.Listener, err error) {
+	if loadBalancerArn == nil {
+		return listeners, nil
+	}
+	input := &elasticloadbalancingv2.DescribeListenersInput{
+		LoadBalancerArn: loadBalancerArn,
+		PageSize:        aws.Int32(400),
+	}
+	output, err := c.DescribeListeners(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	listeners = append(listeners, output.Listeners...)
+	for output.NextMarker != nil {
+		input.Marker = output.NextMarker
+		output, err = c.DescribeListeners(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		listeners = append(listeners, output.Listeners...)
+	}
+	return listeners, nil
 }
 
 func describeELBs(ctx context.Context, c *elasticloadbalancingv2.Client) (elbs []types.LoadBalancer, err error) {

--- a/collector/aws/collector/services.go
+++ b/collector/aws/collector/services.go
@@ -177,6 +177,8 @@ func (s *Services) InitServices(cloudAccountParam schema.CloudAccountParam) (err
 	case ELB:
 		s.ELB = initELBClient(cfg)
 		s.EC2 = initEC2Client(cfg)
+	case ELBListener:
+		s.ELB = initELBClient(cfg)
 	case CLB:
 		s.CLB = initCLBClient(cfg)
 	case FSxFileSystem:

--- a/collector/aws/platform/platform_config.go
+++ b/collector/aws/platform/platform_config.go
@@ -75,6 +75,7 @@ func GetPlatformConfig() *schema.Platform {
 			ec2.GetNetworkInterfaceResource(),
 			rds.GetRDSInstanceResource(),
 			elasticloadbalancing.GetELBResource(),
+			elasticloadbalancing.GetELBListenerResource(),
 			elasticloadbalancing.GetCLBResource(),
 			wafv2.GetWebACLResource(),
 			route53.GetDomainResource(),

--- a/rules/AWS/AWS_ELB_202501162036_910408/policy.rego
+++ b/rules/AWS/AWS_ELB_202501162036_910408/policy.rego
@@ -14,3 +14,8 @@ unsafe_protocol[p] if {
     some p in input.Listeners
     p.Protocol == "HTTP"
 }
+
+unsafe_protocol[p] if {
+    some p in input.Listeners
+    p.Listener.Protocol == "HTTP"
+}

--- a/rules/AWS/AWS_ELBv2_202501081111_765201/policy.rego
+++ b/rules/AWS/AWS_ELBv2_202501081111_765201/policy.rego
@@ -6,6 +6,7 @@ default risk := false
 risk if {
     sg_rule_open_to_all
     pub_lb
+    has_listener
 }
 
 ## 基础信息
@@ -21,13 +22,49 @@ sg_rules contains ip_permission if {
 }
 
 sg_rule_open_to_all if {
-    some ip_ranges in sg_rules[_].IpRanges
-    cidr_ip := ip_ranges.CidrIp
-    cidr_ip == "0.0.0.0/0"
+    some ip_permission in sg_rules
+    sg_rule_open_to_all_public(ip_permission)
+    sg_rule_allows_listener(ip_permission)
 }
 sg_rule_open_to_all if {
     ## 不存在安全组
     not input.SecurityGroups
+}
+
+sg_rule_open_to_all_public(ip_permission) if {
+    some ip_ranges in ip_permission.IpRanges
+    cidr_ip := ip_ranges.CidrIp
+    cidr_ip == "0.0.0.0/0"
+}
+
+sg_rule_allows_listener(ip_permission) if {
+    ip_permission.IpProtocol == "-1"
+}
+
+sg_rule_allows_listener(ip_permission) if {
+    some port in listener_ports
+    from_port := ip_permission.FromPort
+    to_port := ip_permission.ToPort
+    is_number(from_port)
+    is_number(to_port)
+    from_port <= port
+    port <= to_port
+}
+
+has_listener if {
+    count(listener_ports) > 0
+}
+
+listener_ports contains port if {
+    some listener in input.Listeners
+    port := listener.Port
+    is_number(port)
+}
+
+listener_ports contains port if {
+    some listener in input.Listeners
+    port := listener.Listener.Port
+    is_number(port)
 }
 
 ## 公网lb

--- a/rules/AWS/AWS_ELBv2_202501081111_765201/policy.rego
+++ b/rules/AWS/AWS_ELBv2_202501081111_765201/policy.rego
@@ -10,15 +10,15 @@ risk if {
 }
 
 ## 基础信息
-load_balancer_name := input.LoadBalancerName
-dns_name := input.DNSName
+load_balancer_name := input.ELB.LoadBalancerName
+dns_name := input.ELB.DNSName
 
 ## elb 网络类型
-net_scheme := input.Scheme
+net_scheme := input.ELB.Scheme
 
 ## 安全组入向规则
 sg_rules contains ip_permission if {
-    some ip_permission in input.SecurityGroupDetail[_].IpPermissions
+    some ip_permission in input.SecurityGroups[_].SecurityGroup.IpPermissions
 }
 
 sg_rule_open_to_all if {

--- a/rules/AWS/AWS_ELBv2_202501081111_765201/policy_test.rego
+++ b/rules/AWS/AWS_ELBv2_202501081111_765201/policy_test.rego
@@ -1,0 +1,83 @@
+package elb_sg_rule_open_to_all_public_1900001_286
+
+import rego.v1
+
+test_internet_facing_open_sg_without_listener_is_not_risk if {
+	not risk with input as {
+		"ELB": {
+			"Scheme": "internet-facing",
+		},
+		"SecurityGroupDetail": [
+			{
+				"IpPermissions": [
+					{
+						"FromPort": 80,
+						"ToPort":   80,
+						"IpRanges": [
+							{
+								"CidrIp": "0.0.0.0/0",
+							},
+						],
+					},
+				],
+			},
+		],
+		"Listeners": null,
+	}
+}
+
+test_internet_facing_open_sg_with_listener_is_risk if {
+	risk with input as {
+		"ELB": {
+			"Scheme": "internet-facing",
+		},
+		"SecurityGroupDetail": [
+			{
+				"IpPermissions": [
+					{
+						"IpRanges": [
+							{
+								"CidrIp": "0.0.0.0/0",
+							},
+						],
+					},
+				],
+			},
+		],
+		"Listeners": [
+			{
+				"ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/lb/123/456",
+				"Port":        80,
+			},
+		],
+	}
+}
+
+test_internet_facing_sg_open_to_unlistened_port_is_not_risk if {
+	not risk with input as {
+		"ELB": {
+			"Scheme": "internet-facing",
+		},
+		"SecurityGroupDetail": [
+			{
+				"IpPermissions": [
+					{
+						"FromPort": 22,
+						"ToPort":   22,
+						"IpRanges": [
+							{
+								"CidrIp": "0.0.0.0/0",
+							},
+						],
+					},
+				],
+			},
+		],
+		"Listeners": [
+			{
+				"ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/lb/123/456",
+				"Port":        443,
+			},
+		],
+	}
+}

--- a/rules/AWS/AWS_ELBv2_202501081111_765201/policy_test.rego
+++ b/rules/AWS/AWS_ELBv2_202501081111_765201/policy_test.rego
@@ -7,19 +7,21 @@ test_internet_facing_open_sg_without_listener_is_not_risk if {
 		"ELB": {
 			"Scheme": "internet-facing",
 		},
-		"SecurityGroupDetail": [
+		"SecurityGroups": [
 			{
-				"IpPermissions": [
-					{
-						"FromPort": 80,
-						"ToPort":   80,
-						"IpRanges": [
-							{
-								"CidrIp": "0.0.0.0/0",
-							},
-						],
-					},
-				],
+				"SecurityGroup": {
+					"IpPermissions": [
+						{
+							"FromPort": 80,
+							"ToPort":   80,
+							"IpRanges": [
+								{
+									"CidrIp": "0.0.0.0/0",
+								},
+							],
+						},
+					],
+				},
 			},
 		],
 		"Listeners": null,
@@ -31,17 +33,21 @@ test_internet_facing_open_sg_with_listener_is_risk if {
 		"ELB": {
 			"Scheme": "internet-facing",
 		},
-		"SecurityGroupDetail": [
+		"SecurityGroups": [
 			{
-				"IpPermissions": [
-					{
-						"IpRanges": [
-							{
-								"CidrIp": "0.0.0.0/0",
-							},
-						],
-					},
-				],
+				"SecurityGroup": {
+					"IpPermissions": [
+						{
+							"FromPort": 80,
+							"ToPort":   80,
+							"IpRanges": [
+								{
+									"CidrIp": "0.0.0.0/0",
+								},
+							],
+						},
+					],
+				},
 			},
 		],
 		"Listeners": [
@@ -58,19 +64,21 @@ test_internet_facing_sg_open_to_unlistened_port_is_not_risk if {
 		"ELB": {
 			"Scheme": "internet-facing",
 		},
-		"SecurityGroupDetail": [
+		"SecurityGroups": [
 			{
-				"IpPermissions": [
-					{
-						"FromPort": 22,
-						"ToPort":   22,
-						"IpRanges": [
-							{
-								"CidrIp": "0.0.0.0/0",
-							},
-						],
-					},
-				],
+				"SecurityGroup": {
+					"IpPermissions": [
+						{
+							"FromPort": 22,
+							"ToPort":   22,
+							"IpRanges": [
+								{
+									"CidrIp": "0.0.0.0/0",
+								},
+							],
+						},
+					],
+				},
 			},
 		],
 		"Listeners": [


### PR DESCRIPTION
## Summary
- Add AWS ELB Listener collection and include listeners in ELB details.
- Require AWS ELB public exposure findings to have an internet-facing ELB, at least one listener, and a public security-group rule that covers a listener port.
- Keep the AWS ELB HTTP-listener rule compatible with wrapped listener detail input.

## Validation
- go test ./collector/elasticloadbalancing ./collector ./platform
- go test ./... in collector/aws
- git diff --check
- jq empty rules/AWS/AWS_ELB_202501162036_910408/metadata.json rules/AWS/AWS_ELBv2_202501081111_765201/metadata.json

## Notes
- OPA was not available locally, and downloading the binary timed out, so the added Rego regression tests were not executed with opa test.