### PR TITLE
[codex] Prepare CloudRec Lite v0.1.0 release

### DIFF
--- a/.github/workflows/cloudrec-lite-release.yml
+++ b/.github/workflows/cloudrec-lite-release.yml
@@ -20,6 +20,8 @@ jobs:
   release:
     name: Build and attest release artifacts
     runs-on: ubuntu-latest
+    env:
+      GITLEAKS_VERSION: 8.30.1
     defaults:
       run:
         working-directory: lite
@@ -56,21 +58,24 @@ jobs:
         run: go run ./cmd/cloudrec-lite rules validate --rules ./rules/alicloud --provider alicloud --samples ./samples/alicloud --format json
       - name: Release quality gate
         run: go test ./internal/rule -run TestAlicloudReleaseQualityGate -count=1
+      - name: Install Gitleaks CLI
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          base_url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
+          curl -fsSLo "${RUNNER_TEMP}/${archive}" "${base_url}/${archive}"
+          curl -fsSLo "${RUNNER_TEMP}/gitleaks_checksums.txt" "${base_url}/gitleaks_${GITLEAKS_VERSION}_checksums.txt"
+          (cd "${RUNNER_TEMP}" && grep " ${archive}$" gitleaks_checksums.txt | sha256sum -c -)
+          tar -xzf "${RUNNER_TEMP}/${archive}" -C "${RUNNER_TEMP}" gitleaks
+          sudo install -m 0755 "${RUNNER_TEMP}/gitleaks" /usr/local/bin/gitleaks
+          gitleaks version
       - name: Secret scan
         working-directory: ${{ github.workspace }}
         run: |
-          GOTOOLCHAIN=auto GOPROXY=https://proxy.golang.org,direct \
-            go run github.com/zricethezav/gitleaks/v8@latest dir . \
-            --config .gitleaks.toml \
-            --redact \
-            --no-banner \
-            --no-color
-          GOTOOLCHAIN=auto GOPROXY=https://proxy.golang.org,direct \
-            go run github.com/zricethezav/gitleaks/v8@latest git . \
-            --config .gitleaks.toml \
-            --redact \
-            --no-banner \
-            --no-color
+          set -euo pipefail
+          gitleaks dir . --config .gitleaks.toml --redact=100 --no-banner --no-color --verbose
+          gitleaks git . --config .gitleaks.toml --redact=100 --no-banner --no-color --verbose
       - name: Build release artifacts
         run: VERSION="${{ steps.version.outputs.version }}" ./tools/build-release.sh
       - name: Verify release artifacts

--- a/docs/cloudrec-lite-v0.1.0-release-notes.md
+++ b/docs/cloudrec-lite-v0.1.0-release-notes.md
@@ -1,4 +1,4 @@
-# CloudRec Lite v0.1.0 Release Notes Draft
+# CloudRec Lite v0.1.0 Release Notes
 
 CloudRec Lite is a local, single-binary CSPM scanner and dashboard for teams
 that want to quickly inspect cloud asset posture without deploying the full
@@ -16,16 +16,23 @@ CloudRec platform.
 - Asset topology views for public traffic exposure and AK permission paths.
 - OS credential store support through `cloudrec-lite credentials
   store/status/delete`; plaintext `.env.local` is fallback-only.
+- Rules and validation samples are bundled into the binary, so default scans,
+  rule checks, exports, and the Web dashboard work without a separate rules
+  directory.
 
 ## Quickstart
 
 ```sh
 cloudrec-lite version
-printf '%s\n' '<access-key-id>' | cloudrec-lite credentials store --provider alicloud --account <account-id> --access-key-id-stdin
-cloudrec-lite doctor --provider alicloud --account <account-id> --rules ./rules/alicloud
-cloudrec-lite scan --provider alicloud --account <account-id> --rules ./rules/alicloud --dry-run=false
-cloudrec-lite serve --rules ./rules/alicloud --provider alicloud
+cloudrec-lite credentials store --provider alicloud --account <account-id> --access-key-id <access-key-id>
+cloudrec-lite doctor --provider alicloud --account <account-id>
+cloudrec-lite scan --provider alicloud --account <account-id> --dry-run=false
+cloudrec-lite serve --provider alicloud
 ```
+
+`credentials store` reads the AccessKey secret through an interactive hidden
+prompt by default. For automation, pass `--access-key-id-stdin` and
+`--secret-stdin` so credential values do not appear in shell history.
 
 The default SQLite database is stored under the user's configuration directory
 as `cloudrec-lite/cloudrec-lite.db`; pass `--db <path>` for temporary or


### PR DESCRIPTION
## Summary
- finalize CloudRec Lite v0.1.0 release notes for the bundled-rules single-binary flow
- pin the release workflow secret scan to the verified Gitleaks CLI installer path
- keep the release workflow gates in place before publishing tag-triggered artifacts

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cloudrec-lite-release.yml"); puts "yaml ok"'`

Note: local macOS Gitleaks binary download was slow, so the full Gitleaks/Go/rule gates are intentionally left to the PR GitHub Actions release and secret-scan checks.
