### PR TITLE
[codex] stream AWS ELBv2 collector results

### DIFF
--- a/collector/aws/collector/elasticloadbalancing/elasticloadbalancingv2.go
+++ b/collector/aws/collector/elasticloadbalancing/elasticloadbalancingv2.go
@@ -19,7 +19,6 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	ec2_2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	types2 "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
@@ -84,47 +83,12 @@ func GetELBDetail(ctx context.Context, iService schema.ServiceInterface, res cha
 	elbClient := iService.(*collector.Services).ELB
 	ec2Client := iService.(*collector.Services).EC2
 
-	ELBDetails, err := describeELBDetails(ctx, elbClient, ec2Client)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("describeELBDetails error", zap.Error(err))
-		return err
-	}
-
-	for _, elb := range ELBDetails {
-		res <- elb
-	}
-
-	return nil
-}
-
-func GetELBListenerDetail(ctx context.Context, iService schema.ServiceInterface, res chan<- any) error {
-	elbClient := iService.(*collector.Services).ELB
-
-	listeners, err := describeELBListeners(ctx, elbClient)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("describeELBListeners error", zap.Error(err))
-		return err
-	}
-
-	for _, listener := range listeners {
-		res <- ELBListenerDetail{Listener: listener}
-	}
-
-	return nil
-}
-
-func describeELBDetails(ctx context.Context, elbClient *elasticloadbalancingv2.Client, ec2Client *ec2_2.Client) (ELBDetails []ELBDetail, err error) {
-	elbs, err := describeELBs(ctx, elbClient)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, elb := range elbs {
+	return forEachELB(ctx, elbClient, func(elb types.LoadBalancer) error {
 		listeners, err := describeELBListenersByLoadBalancerArn(ctx, elbClient, elb.LoadBalancerArn)
 		if err != nil {
 			log.CtxLogger(ctx).Warn("DescribeListeners error", zap.Error(err), zap.String("loadBalancerArn", aws.ToString(elb.LoadBalancerArn)))
 		}
-		ELBDetails = append(ELBDetails, ELBDetail{
+		res <- ELBDetail{
 			ELB:       elb,
 			Listeners: listeners,
 			VPC: ec2.DescribeVPCDetailsByFilters(ctx, ec2Client, []types2.Filter{
@@ -139,25 +103,25 @@ func describeELBDetails(ctx context.Context, elbClient *elasticloadbalancingv2.C
 					Values: elb.SecurityGroups,
 				},
 			}),
-		})
-	}
-	return ELBDetails, nil
+		}
+		return nil
+	})
 }
 
-func describeELBListeners(ctx context.Context, c *elasticloadbalancingv2.Client) (listeners []types.Listener, err error) {
-	elbs, err := describeELBs(ctx, c)
-	if err != nil {
-		return nil, err
-	}
-	for _, elb := range elbs {
-		lbListeners, err := describeELBListenersByLoadBalancerArn(ctx, c, elb.LoadBalancerArn)
+func GetELBListenerDetail(ctx context.Context, iService schema.ServiceInterface, res chan<- any) error {
+	elbClient := iService.(*collector.Services).ELB
+
+	return forEachELB(ctx, elbClient, func(elb types.LoadBalancer) error {
+		listeners, err := describeELBListenersByLoadBalancerArn(ctx, elbClient, elb.LoadBalancerArn)
 		if err != nil {
 			log.CtxLogger(ctx).Warn("DescribeListeners error", zap.Error(err), zap.String("loadBalancerArn", aws.ToString(elb.LoadBalancerArn)))
-			continue
+			return nil
 		}
-		listeners = append(listeners, lbListeners...)
-	}
-	return listeners, nil
+		for _, listener := range listeners {
+			res <- ELBListenerDetail{Listener: listener}
+		}
+		return nil
+	})
 }
 
 func describeELBListenersByLoadBalancerArn(ctx context.Context, c *elasticloadbalancingv2.Client, loadBalancerArn *string) (listeners []types.Listener, err error) {
@@ -184,24 +148,24 @@ func describeELBListenersByLoadBalancerArn(ctx context.Context, c *elasticloadba
 	return listeners, nil
 }
 
-func describeELBs(ctx context.Context, c *elasticloadbalancingv2.Client) (elbs []types.LoadBalancer, err error) {
+func forEachELB(ctx context.Context, c *elasticloadbalancingv2.Client, handle func(types.LoadBalancer) error) error {
 	input := &elasticloadbalancingv2.DescribeLoadBalancersInput{
 		PageSize: aws.Int32(400),
 	}
-	output, err := c.DescribeLoadBalancers(ctx, input)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("DescribeLoadBalancers error", zap.Error(err))
-		return nil, err
-	}
-	elbs = append(elbs, output.LoadBalancers...)
-	for output.NextMarker != nil {
-		input.Marker = output.NextMarker
-		output, err = c.DescribeLoadBalancers(ctx, input)
+	for {
+		output, err := c.DescribeLoadBalancers(ctx, input)
 		if err != nil {
 			log.CtxLogger(ctx).Warn("DescribeLoadBalancers error", zap.Error(err))
-			return nil, err
+			return err
 		}
-		elbs = append(elbs, output.LoadBalancers...)
+		for _, elb := range output.LoadBalancers {
+			if err := handle(elb); err != nil {
+				return err
+			}
+		}
+		if output.NextMarker == nil {
+			return nil
+		}
+		input.Marker = output.NextMarker
 	}
-	return elbs, nil
 }

--- a/collector/aws/collector/elasticloadbalancing/elasticloadbalancingv2.go
+++ b/collector/aws/collector/elasticloadbalancing/elasticloadbalancingv2.go
@@ -17,6 +17,7 @@ package elasticloadbalancing
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	types2 "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -29,6 +30,11 @@ import (
 	"github.com/core-sdk/schema"
 	"go.uber.org/zap"
 )
+
+type elbv2API interface {
+	DescribeLoadBalancers(context.Context, *elasticloadbalancingv2.DescribeLoadBalancersInput, ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeLoadBalancersOutput, error)
+	DescribeListeners(context.Context, *elasticloadbalancingv2.DescribeListenersInput, ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeListenersOutput, error)
+}
 
 // GetELBResource returns a  ELB Resource
 // ELB is elasticloadbalancingv2
@@ -83,48 +89,122 @@ func GetELBDetail(ctx context.Context, iService schema.ServiceInterface, res cha
 	elbClient := iService.(*collector.Services).ELB
 	ec2Client := iService.(*collector.Services).EC2
 
-	return forEachELB(ctx, elbClient, func(elb types.LoadBalancer) error {
-		listeners, err := describeELBListenersByLoadBalancerArn(ctx, elbClient, elb.LoadBalancerArn)
-		if err != nil {
-			log.CtxLogger(ctx).Warn("DescribeListeners error", zap.Error(err), zap.String("loadBalancerArn", aws.ToString(elb.LoadBalancerArn)))
-		}
-		res <- ELBDetail{
-			ELB:       elb,
-			Listeners: listeners,
-			VPC: ec2.DescribeVPCDetailsByFilters(ctx, ec2Client, []types2.Filter{
+	return streamELBDetails(
+		ctx,
+		elbClient,
+		res,
+		func(ctx context.Context, elb types.LoadBalancer) []ec2.VPCDetail {
+			if elb.VpcId == nil {
+				return nil
+			}
+			return ec2.DescribeVPCDetailsByFilters(ctx, ec2Client, []types2.Filter{
 				{
 					Name:   aws.String("vpc-id"),
 					Values: []string{*elb.VpcId},
 				},
-			}),
-			SecurityGroups: ec2.DescribeSecurityGroupDetailsByFilters(ctx, ec2Client, []types2.Filter{
+			})
+		},
+		func(ctx context.Context, elb types.LoadBalancer) []ec2.SecurityGroupDetail {
+			return ec2.DescribeSecurityGroupDetailsByFilters(ctx, ec2Client, []types2.Filter{
 				{
 					Name:   aws.String("group-id"),
 					Values: elb.SecurityGroups,
 				},
-			}),
-		}
-		return nil
-	})
+			})
+		},
+	)
 }
 
 func GetELBListenerDetail(ctx context.Context, iService schema.ServiceInterface, res chan<- any) error {
 	elbClient := iService.(*collector.Services).ELB
 
-	return forEachELB(ctx, elbClient, func(elb types.LoadBalancer) error {
-		listeners, err := describeELBListenersByLoadBalancerArn(ctx, elbClient, elb.LoadBalancerArn)
+	return streamELBListeners(ctx, elbClient, res)
+}
+
+func streamELBDetails(
+	ctx context.Context,
+	c elbv2API,
+	res chan<- any,
+	describeVPCDetails func(context.Context, types.LoadBalancer) []ec2.VPCDetail,
+	describeSecurityGroupDetails func(context.Context, types.LoadBalancer) []ec2.SecurityGroupDetail,
+) error {
+	start := time.Now()
+	var processed, listenerCount, listenerErrorCount int
+	log.CtxLogger(ctx).Info("Start streaming ELB details")
+	defer func() {
+		log.CtxLogger(ctx).Info("Finished streaming ELB details",
+			zap.Int("processedLoadBalancers", processed),
+			zap.Int("listeners", listenerCount),
+			zap.Int("listenerErrors", listenerErrorCount),
+			zap.Duration("duration", time.Since(start)))
+	}()
+
+	return forEachELB(ctx, c, func(elb types.LoadBalancer) error {
+		listeners, err := describeELBListenersByLoadBalancerArn(ctx, c, elb.LoadBalancerArn)
 		if err != nil {
+			listenerErrorCount++
 			log.CtxLogger(ctx).Warn("DescribeListeners error", zap.Error(err), zap.String("loadBalancerArn", aws.ToString(elb.LoadBalancerArn)))
+		}
+		detail := ELBDetail{
+			ELB:       elb,
+			Listeners: listeners,
+		}
+		if describeVPCDetails != nil {
+			detail.VPC = describeVPCDetails(ctx, elb)
+		}
+		if describeSecurityGroupDetails != nil {
+			detail.SecurityGroups = describeSecurityGroupDetails(ctx, elb)
+		}
+		res <- detail
+
+		processed++
+		listenerCount += len(listeners)
+		logELBProgress(ctx, "Streaming ELB detail progress", processed, listenerCount, listenerErrorCount)
+		return nil
+	})
+}
+
+func streamELBListeners(ctx context.Context, c elbv2API, res chan<- any) error {
+	start := time.Now()
+	var processed, listenerCount, listenerErrorCount int
+	log.CtxLogger(ctx).Info("Start streaming ELB listeners")
+	defer func() {
+		log.CtxLogger(ctx).Info("Finished streaming ELB listeners",
+			zap.Int("processedLoadBalancers", processed),
+			zap.Int("listeners", listenerCount),
+			zap.Int("listenerErrors", listenerErrorCount),
+			zap.Duration("duration", time.Since(start)))
+	}()
+
+	return forEachELB(ctx, c, func(elb types.LoadBalancer) error {
+		listeners, err := describeELBListenersByLoadBalancerArn(ctx, c, elb.LoadBalancerArn)
+		processed++
+		if err != nil {
+			listenerErrorCount++
+			log.CtxLogger(ctx).Warn("DescribeListeners error", zap.Error(err), zap.String("loadBalancerArn", aws.ToString(elb.LoadBalancerArn)))
+			logELBProgress(ctx, "Streaming ELB listener progress", processed, listenerCount, listenerErrorCount)
 			return nil
 		}
 		for _, listener := range listeners {
 			res <- ELBListenerDetail{Listener: listener}
 		}
+
+		listenerCount += len(listeners)
+		logELBProgress(ctx, "Streaming ELB listener progress", processed, listenerCount, listenerErrorCount)
 		return nil
 	})
 }
 
-func describeELBListenersByLoadBalancerArn(ctx context.Context, c *elasticloadbalancingv2.Client, loadBalancerArn *string) (listeners []types.Listener, err error) {
+func logELBProgress(ctx context.Context, msg string, processed int, listenerCount int, listenerErrorCount int) {
+	if processed == 1 || processed%50 == 0 {
+		log.CtxLogger(ctx).Info(msg,
+			zap.Int("processedLoadBalancers", processed),
+			zap.Int("listeners", listenerCount),
+			zap.Int("listenerErrors", listenerErrorCount))
+	}
+}
+
+func describeELBListenersByLoadBalancerArn(ctx context.Context, c elbv2API, loadBalancerArn *string) (listeners []types.Listener, err error) {
 	if loadBalancerArn == nil {
 		return listeners, nil
 	}
@@ -148,16 +228,23 @@ func describeELBListenersByLoadBalancerArn(ctx context.Context, c *elasticloadba
 	return listeners, nil
 }
 
-func forEachELB(ctx context.Context, c *elasticloadbalancingv2.Client, handle func(types.LoadBalancer) error) error {
+func forEachELB(ctx context.Context, c elbv2API, handle func(types.LoadBalancer) error) error {
 	input := &elasticloadbalancingv2.DescribeLoadBalancersInput{
 		PageSize: aws.Int32(400),
 	}
+	var page, total int
 	for {
 		output, err := c.DescribeLoadBalancers(ctx, input)
 		if err != nil {
 			log.CtxLogger(ctx).Warn("DescribeLoadBalancers error", zap.Error(err))
 			return err
 		}
+		page++
+		total += len(output.LoadBalancers)
+		log.CtxLogger(ctx).Info("DescribeLoadBalancers page received",
+			zap.Int("page", page),
+			zap.Int("pageLoadBalancers", len(output.LoadBalancers)),
+			zap.Int("totalLoadBalancers", total))
 		for _, elb := range output.LoadBalancers {
 			if err := handle(elb); err != nil {
 				return err

--- a/collector/aws/collector/elasticloadbalancing/elasticloadbalancingv2_test.go
+++ b/collector/aws/collector/elasticloadbalancing/elasticloadbalancingv2_test.go
@@ -1,0 +1,156 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elasticloadbalancing
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+)
+
+type fakeELBV2Client struct {
+	loadBalancers    []types.LoadBalancer
+	blockAfterCalls  int
+	unblockListeners chan struct{}
+
+	mu            sync.Mutex
+	listenerCalls int
+}
+
+func (f *fakeELBV2Client) DescribeLoadBalancers(context.Context, *elasticloadbalancingv2.DescribeLoadBalancersInput, ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeLoadBalancersOutput, error) {
+	return &elasticloadbalancingv2.DescribeLoadBalancersOutput{
+		LoadBalancers: f.loadBalancers,
+	}, nil
+}
+
+func (f *fakeELBV2Client) DescribeListeners(ctx context.Context, input *elasticloadbalancingv2.DescribeListenersInput, _ ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeListenersOutput, error) {
+	f.mu.Lock()
+	f.listenerCalls++
+	call := f.listenerCalls
+	f.mu.Unlock()
+
+	if f.blockAfterCalls > 0 && call > f.blockAfterCalls && f.unblockListeners != nil {
+		select {
+		case <-f.unblockListeners:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	return &elasticloadbalancingv2.DescribeListenersOutput{
+		Listeners: []types.Listener{
+			{
+				ListenerArn:     aws.String(fmt.Sprintf("listener-%d", call)),
+				LoadBalancerArn: input.LoadBalancerArn,
+				Port:            aws.Int32(80),
+			},
+		},
+	}, nil
+}
+
+func TestStreamELBDetailsPushesFirstResultBeforeAllLoadBalancersFinish(t *testing.T) {
+	unblockListeners := make(chan struct{})
+	client := &fakeELBV2Client{
+		loadBalancers:    makeLoadBalancers(5),
+		blockAfterCalls:  1,
+		unblockListeners: unblockListeners,
+	}
+	res := make(chan any, len(client.loadBalancers))
+	done := make(chan error, 1)
+
+	go func() {
+		done <- streamELBDetails(context.Background(), client, res, nil, nil)
+	}()
+
+	got := receiveFirstResult(t, res)
+	detail, ok := got.(ELBDetail)
+	if !ok {
+		t.Fatalf("got %T, want ELBDetail", got)
+	}
+	if len(detail.Listeners) != 1 {
+		t.Fatalf("listener count = %d, want 1", len(detail.Listeners))
+	}
+	close(unblockListeners)
+
+	if err := <-done; err != nil {
+		t.Fatalf("streamELBDetails returned error: %v", err)
+	}
+	if got := 1 + len(res); got != len(client.loadBalancers) {
+		t.Fatalf("streamed ELB detail count = %d, want %d", got, len(client.loadBalancers))
+	}
+}
+
+func TestStreamELBListenersPushesFirstResultBeforeAllLoadBalancersFinish(t *testing.T) {
+	unblockListeners := make(chan struct{})
+	client := &fakeELBV2Client{
+		loadBalancers:    makeLoadBalancers(5),
+		blockAfterCalls:  1,
+		unblockListeners: unblockListeners,
+	}
+	res := make(chan any, len(client.loadBalancers))
+	done := make(chan error, 1)
+
+	go func() {
+		done <- streamELBListeners(context.Background(), client, res)
+	}()
+
+	got := receiveFirstResult(t, res)
+	detail, ok := got.(ELBListenerDetail)
+	if !ok {
+		t.Fatalf("got %T, want ELBListenerDetail", got)
+	}
+	if detail.Listener.ListenerArn == nil {
+		t.Fatal("listener arn is nil")
+	}
+	close(unblockListeners)
+
+	if err := <-done; err != nil {
+		t.Fatalf("streamELBListeners returned error: %v", err)
+	}
+	if got := 1 + len(res); got != len(client.loadBalancers) {
+		t.Fatalf("streamed ELB listener count = %d, want %d", got, len(client.loadBalancers))
+	}
+}
+
+func receiveFirstResult(t *testing.T, res <-chan any) any {
+	t.Helper()
+	select {
+	case got := <-res:
+		return got
+	case <-time.After(time.Second):
+		t.Fatal("collector did not stream first result before processing all load balancers")
+	}
+	return nil
+}
+
+func makeLoadBalancers(count int) []types.LoadBalancer {
+	loadBalancers := make([]types.LoadBalancer, 0, count)
+	for i := 0; i < count; i++ {
+		loadBalancers = append(loadBalancers, types.LoadBalancer{
+			LoadBalancerArn:  aws.String(fmt.Sprintf("lb-%d", i)),
+			LoadBalancerName: aws.String(fmt.Sprintf("lb-%d", i)),
+			SecurityGroups:   []string{fmt.Sprintf("sg-%d", i)},
+			VpcId:            aws.String(fmt.Sprintf("vpc-%d", i)),
+		})
+	}
+	return loadBalancers
+}


### PR DESCRIPTION
## Summary
- Change AWS ELBv2 collection from batch-then-push to streaming push per load balancer.
- Stream the standalone ELB Listener resource as listeners are discovered instead of collecting all listeners before sending.
- Add deterministic streaming regression tests that would fail if the collector waits for every load balancer before emitting the first result.
- Add ELBv2 progress logs for load-balancer pages, processed load balancers, listener count, listener errors, and collection duration.

## Root cause
PR #114 added per-load-balancer `DescribeListeners` calls, but the AWS ELBv2 collector still built the entire region result set before sending anything to `regionCh`. In regions with many ALB/NLB resources, that left the framework consumer idle long enough to hit the hard-coded 30s timeout, close the channel, and drop the whole region.

## Validation
- `go test ./collector/elasticloadbalancing -run 'TestStreamELB' -count=1`
- `go test ./collector/elasticloadbalancing ./collector ./platform`
- `go test ./...` in `collector/aws`
- `git diff --check`
