### PR TITLE
[Feat]  Improve AWS Collector Reliability with Incremental Streaming

### DIFF
--- a/collector/aws/collector/acm/certificate.go
+++ b/collector/aws/collector/acm/certificate.go
@@ -49,6 +49,10 @@ type CertificateDetail struct {
 }
 
 // GetCertificateDetail fetches the details for all ACM certificates.
+// Each detail is pushed to res as its per-certificate Describe and
+// ListTags calls finish; do not refactor this into a build-slice-then-
+// push pattern, as that would risk the 30s consumer idle timeout in
+// core-sdk schema/platform.go (see commit 8295d1b).
 func GetCertificateDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).ACM
 

--- a/collector/aws/collector/acm/certificate.go
+++ b/collector/aws/collector/acm/certificate.go
@@ -49,46 +49,31 @@ type CertificateDetail struct {
 }
 
 // GetCertificateDetail fetches the details for all ACM certificates.
-// Each detail is pushed to res as its per-certificate Describe and
-// ListTags calls finish; do not refactor this into a build-slice-then-
-// push pattern, as that would risk the 30s consumer idle timeout in
-// core-sdk schema/platform.go (see commit 8295d1b).
+// Both the ListCertificates pagination and the per-certificate Describe /
+// ListTags calls stream incrementally — each certificate is pushed to res
+// as soon as its page is listed and its detail calls finish. Do not
+// refactor back to a build-slice-then-push pattern, as that would risk the
+// 30s consumer idle timeout in core-sdk schema/platform.go (see commit
+// 8295d1b).
 func GetCertificateDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).ACM
 
-	certificates, err := listCertificates(ctx, client)
-	if err != nil {
-		log.CtxLogger(ctx).Error("failed to list certificates", zap.Error(err))
-		return err
-	}
-
-	for _, certificate := range certificates {
-
-		certificateDetail := describeCertificate(ctx, client, certificate.CertificateArn)
-
-		tags := listCertificateTags(ctx, client, certificate.CertificateArn)
-
-		res <- &CertificateDetail{
-			Certificate: certificateDetail,
-			Tags:        tags,
+	paginator := acm.NewListCertificatesPaginator(client, &acm.ListCertificatesInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			log.CtxLogger(ctx).Error("failed to list certificates", zap.Error(err))
+			return err
+		}
+		for _, certificate := range page.CertificateSummaryList {
+			res <- &CertificateDetail{
+				Certificate: describeCertificate(ctx, client, certificate.CertificateArn),
+				Tags:        listCertificateTags(ctx, client, certificate.CertificateArn),
+			}
 		}
 	}
 
 	return nil
-}
-
-// listCertificates retrieves all ACM certificates.
-func listCertificates(ctx context.Context, c *acm.Client) ([]types.CertificateSummary, error) {
-	var certificates []types.CertificateSummary
-	paginator := acm.NewListCertificatesPaginator(c, &acm.ListCertificatesInput{})
-	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, err
-		}
-		certificates = append(certificates, page.CertificateSummaryList...)
-	}
-	return certificates, nil
 }
 
 // describeCertificate retrieves detailed information for a certificate.

--- a/collector/aws/collector/ec2/ec2.go
+++ b/collector/aws/collector/ec2/ec2.go
@@ -58,55 +58,39 @@ type InstanceDetail struct {
 	// any information about EC2 instance
 }
 
-// GetInstanceDetail streams each EC2 instance detail as its security
-// group lookup completes, avoiding the 30s consumer idle timeout in
-// core-sdk schema/platform.go when a region has many instances.
+// GetInstanceDetail streams each EC2 instance detail as the
+// DescribeInstances pagination yields it and its security group lookup
+// completes — both the listing and the per-instance enrich push
+// incrementally, avoiding the 30s consumer idle timeout in core-sdk
+// schema/platform.go when a region has many instances.
 func GetInstanceDetail(ctx context.Context, iService schema.ServiceInterface, res chan<- any) (err error) {
 	client := iService.(*collector.Services).EC2
 
-	instances, err := describeInstance(ctx, client)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("describeInstance failed", zap.Error(err))
-		return err
-	}
-
-	for _, instance := range instances {
-		res <- InstanceDetail{
-			Instance: instance,
-			SecurityGroups: DescribeSecurityGroupDetailsByFilters(ctx, client, []types.Filter{
-				{
-					Name:   aws.String("group-id"),
-					Values: getInstanceSecurityGroupIds(instance),
-				},
-			}),
+	input := &ec2.DescribeInstancesInput{}
+	for {
+		output, err := client.DescribeInstances(ctx, input)
+		if err != nil {
+			log.CtxLogger(ctx).Warn("describeInstance failed", zap.Error(err))
+			return err
 		}
-	}
-
-	return nil
-}
-
-func describeInstance(ctx context.Context, client *ec2.Client) (instances []types.Instance, err error) {
-	input := &ec2.DescribeInstancesInput{
-		NextToken: nil,
-	}
-	output, err := client.DescribeInstances(ctx, input)
-	if err != nil {
-		return nil, err
-	}
-	for _, reservation := range output.Reservations {
-		instances = append(instances, reservation.Instances...)
-	}
-	for output.NextToken != nil {
-		input = &ec2.DescribeInstancesInput{
-			NextToken: output.NextToken,
-		}
-		output, err = client.DescribeInstances(ctx, input)
 		for _, reservation := range output.Reservations {
-			instances = append(instances, reservation.Instances...)
+			for _, instance := range reservation.Instances {
+				res <- InstanceDetail{
+					Instance: instance,
+					SecurityGroups: DescribeSecurityGroupDetailsByFilters(ctx, client, []types.Filter{
+						{
+							Name:   aws.String("group-id"),
+							Values: getInstanceSecurityGroupIds(instance),
+						},
+					}),
+				}
+			}
 		}
+		if output.NextToken == nil {
+			return nil
+		}
+		input.NextToken = output.NextToken
 	}
-
-	return instances, err
 }
 
 func getInstanceSecurityGroupIds(instance types.Instance) (ids []string) {

--- a/collector/aws/collector/ec2/ec2.go
+++ b/collector/aws/collector/ec2/ec2.go
@@ -58,31 +58,20 @@ type InstanceDetail struct {
 	// any information about EC2 instance
 }
 
-// GetInstanceDetail gets all InstanceDetail struct instances and sends them to a channel received by server finally, returns error
+// GetInstanceDetail streams each EC2 instance detail as its security
+// group lookup completes, avoiding the 30s consumer idle timeout in
+// core-sdk schema/platform.go when a region has many instances.
 func GetInstanceDetail(ctx context.Context, iService schema.ServiceInterface, res chan<- any) (err error) {
-	// 1. get client
 	client := iService.(*collector.Services).EC2
 
-	// 2. invoke api of sdk to describe InstanceDetail struct instances
-	instanceDetails, err := describeInstanceDetails(ctx, client)
+	instances, err := describeInstance(ctx, client)
 	if err != nil {
-		log.CtxLogger(ctx).Warn("describeInstanceDetails failed, err", zap.Error(err))
+		log.CtxLogger(ctx).Warn("describeInstance failed", zap.Error(err))
 		return err
 	}
 
-	// 3. send instances to channel
-	for _, instanceDetail := range instanceDetails {
-		res <- instanceDetail
-	}
-
-	return nil
-}
-
-func describeInstanceDetails(ctx context.Context, client *ec2.Client) (instanceDetails []InstanceDetail, err error) {
-	instances, err := describeInstance(ctx, client)
-
 	for _, instance := range instances {
-		instanceDetails = append(instanceDetails, InstanceDetail{
+		res <- InstanceDetail{
 			Instance: instance,
 			SecurityGroups: DescribeSecurityGroupDetailsByFilters(ctx, client, []types.Filter{
 				{
@@ -90,10 +79,10 @@ func describeInstanceDetails(ctx context.Context, client *ec2.Client) (instanceD
 					Values: getInstanceSecurityGroupIds(instance),
 				},
 			}),
-		})
+		}
 	}
 
-	return instanceDetails, nil
+	return nil
 }
 
 func describeInstance(ctx context.Context, client *ec2.Client) (instances []types.Instance, err error) {

--- a/collector/aws/collector/ec2/security_group.go
+++ b/collector/aws/collector/ec2/security_group.go
@@ -52,40 +52,44 @@ type SecurityGroupDetail struct {
 	SecurityGroupRules []types.SecurityGroupRule
 }
 
-// GetSecurityGroupDetail streams each SecurityGroupDetail as soon as its
-// rules are fetched, avoiding the 30s consumer idle timeout in core-sdk
-// schema/platform.go. If the per-SG rule fetch fails, the SG is still
-// emitted with nil rules — mirroring the existing
-// DescribeSecurityGroupDetailsByFilters helper (the previous code path
-// dropped the SG entirely, which was inconsistent).
+// GetSecurityGroupDetail streams each SecurityGroupDetail as the
+// DescribeSecurityGroups pagination yields it and its rules are fetched,
+// avoiding the 30s consumer idle timeout in core-sdk schema/platform.go.
+// If the per-SG rule fetch fails, the SG is still emitted with nil rules —
+// mirroring the existing DescribeSecurityGroupDetailsByFilters helper (the
+// previous code path dropped the SG entirely, which was inconsistent).
 func GetSecurityGroupDetail(ctx context.Context, iService schema.ServiceInterface, res chan<- any) (err error) {
 	client := iService.(*collector.Services).EC2
 
-	securityGroups, err := describeSecurityGroups(ctx, client)
-	if err != nil {
-		return err
-	}
-
-	for _, securityGroup := range securityGroups {
-		if securityGroup.GroupId == nil {
-			continue
-		}
-		securityGroupRules, err := describeSecurityGroupRulesByFilters(ctx, client, []types.Filter{
-			{
-				Name:   aws.String("group-id"),
-				Values: []string{*securityGroup.GroupId},
-			},
-		})
+	input := &ec2.DescribeSecurityGroupsInput{}
+	for {
+		output, err := client.DescribeSecurityGroups(ctx, input)
 		if err != nil {
-			log.CtxLogger(ctx).Warn("describe security group rule failed", zap.Error(err))
+			return err
 		}
-		res <- SecurityGroupDetail{
-			SecurityGroup:      securityGroup,
-			SecurityGroupRules: securityGroupRules,
+		for _, securityGroup := range output.SecurityGroups {
+			if securityGroup.GroupId == nil {
+				continue
+			}
+			securityGroupRules, err := describeSecurityGroupRulesByFilters(ctx, client, []types.Filter{
+				{
+					Name:   aws.String("group-id"),
+					Values: []string{*securityGroup.GroupId},
+				},
+			})
+			if err != nil {
+				log.CtxLogger(ctx).Warn("describe security group rule failed", zap.Error(err))
+			}
+			res <- SecurityGroupDetail{
+				SecurityGroup:      securityGroup,
+				SecurityGroupRules: securityGroupRules,
+			}
 		}
+		if output.NextToken == nil {
+			return nil
+		}
+		input.NextToken = output.NextToken
 	}
-
-	return nil
 }
 
 func DescribeSecurityGroupDetailsByFilters(ctx context.Context, c *ec2.Client, filters []types.Filter) (securityGroupDetails []SecurityGroupDetail) {
@@ -150,22 +154,4 @@ func describeSecurityGroupRulesByFilters(ctx context.Context, c *ec2.Client, fil
 		securityGroupRules = append(securityGroupRules, output.SecurityGroupRules...)
 	}
 	return securityGroupRules, nil
-}
-
-func describeSecurityGroups(ctx context.Context, c *ec2.Client) (securityGroups []types.SecurityGroup, err error) {
-	input := &ec2.DescribeSecurityGroupsInput{}
-	output, err := c.DescribeSecurityGroups(ctx, input)
-	if err != nil {
-		return nil, err
-	}
-	securityGroups = append(securityGroups, output.SecurityGroups...)
-	for output.NextToken != nil {
-		input.NextToken = output.NextToken
-		output, err = c.DescribeSecurityGroups(ctx, input)
-		if err != nil {
-			return nil, err
-		}
-		securityGroups = append(securityGroups, output.SecurityGroups...)
-	}
-	return securityGroups, nil
 }

--- a/collector/aws/collector/ec2/security_group.go
+++ b/collector/aws/collector/ec2/security_group.go
@@ -52,47 +52,40 @@ type SecurityGroupDetail struct {
 	SecurityGroupRules []types.SecurityGroupRule
 }
 
+// GetSecurityGroupDetail streams each SecurityGroupDetail as soon as its
+// rules are fetched, avoiding the 30s consumer idle timeout in core-sdk
+// schema/platform.go. If the per-SG rule fetch fails, the SG is still
+// emitted with nil rules — mirroring the existing
+// DescribeSecurityGroupDetailsByFilters helper (the previous code path
+// dropped the SG entirely, which was inconsistent).
 func GetSecurityGroupDetail(ctx context.Context, iService schema.ServiceInterface, res chan<- any) (err error) {
 	client := iService.(*collector.Services).EC2
 
-	securityGroupDetails, err := describeSecurityGroupDetails(ctx, client)
+	securityGroups, err := describeSecurityGroups(ctx, client)
 	if err != nil {
 		return err
 	}
 
-	for _, securityGroupDetail := range securityGroupDetails {
-		res <- securityGroupDetail
-	}
-
-	return nil
-}
-
-// describeSecurityGroupDetails Describe SecurityGroupDetail with all your security group.
-// If you want to expand SecurityGroupDetail, expand this function
-func describeSecurityGroupDetails(ctx context.Context, c *ec2.Client) (securityGroupDetails []SecurityGroupDetail, err error) {
-
-	securityGroups, err := describeSecurityGroups(ctx, c)
-	if err != nil {
-		return nil, err
-	}
-
 	for _, securityGroup := range securityGroups {
-		securityGroupRules, err := describeSecurityGroupRulesByFilters(ctx, c, []types.Filter{
+		if securityGroup.GroupId == nil {
+			continue
+		}
+		securityGroupRules, err := describeSecurityGroupRulesByFilters(ctx, client, []types.Filter{
 			{
 				Name:   aws.String("group-id"),
 				Values: []string{*securityGroup.GroupId},
 			},
 		})
 		if err != nil {
-			continue
+			log.CtxLogger(ctx).Warn("describe security group rule failed", zap.Error(err))
 		}
-		securityGroupDetails = append(securityGroupDetails, SecurityGroupDetail{
+		res <- SecurityGroupDetail{
 			SecurityGroup:      securityGroup,
 			SecurityGroupRules: securityGroupRules,
-		})
+		}
 	}
 
-	return securityGroupDetails, nil
+	return nil
 }
 
 func DescribeSecurityGroupDetailsByFilters(ctx context.Context, c *ec2.Client, filters []types.Filter) (securityGroupDetails []SecurityGroupDetail) {

--- a/collector/aws/collector/ec2/vpc.go
+++ b/collector/aws/collector/ec2/vpc.go
@@ -70,46 +70,51 @@ type VPCDetail struct {
 	VPNConnections []types.VpnConnection
 }
 
-// GetVPCDetail streams each VPC detail incrementally; each VPC fans out
-// to six secondary describe calls (Subnets/ACLs/Endpoints/Peering/VPN/
-// RouteTables), so buffering them all before pushing would risk the
-// core-sdk consumer's 30s idle timeout (see schema/platform.go).
+// GetVPCDetail streams each VPC detail incrementally as the DescribeVpcs
+// pagination yields it; each VPC fans out to six secondary describe calls
+// (Subnets/ACLs/Endpoints/Peering/VPN/RouteTables), so buffering the list
+// or the details before pushing would risk the core-sdk consumer's 30s
+// idle timeout (see schema/platform.go).
 func GetVPCDetail(ctx context.Context, iService schema.ServiceInterface, res chan<- any) error {
 	client := iService.(*collector.Services).EC2
 
-	vpcs, err := describeVpcs(ctx, client)
-	if err != nil {
-		return err
-	}
-
-	for _, vpc := range vpcs {
-		if vpc.VpcId == nil {
-			continue
+	input := &ec2.DescribeVpcsInput{}
+	for {
+		output, err := client.DescribeVpcs(ctx, input)
+		if err != nil {
+			return err
 		}
-		vpcId := *vpc.VpcId
-		res <- VPCDetail{
-			VPC:  vpc,
-			Name: utils.GetNameFromTags(vpc.Tags),
-			Subnets: DescribeSubnetsByFilters(ctx, client, []types.Filter{
-				{
-					Name:   aws.String("vpc-id"),
-					Values: []string{vpcId},
-				},
-			}),
-			ACLs: DescribeNetworkAclsByFilters(ctx, client, []types.Filter{
-				{
-					Name:   aws.String("vpc-id"),
-					Values: []string{vpcId},
-				},
-			}),
-			VPCEndpoints:          describeVpcEndpoints(ctx, client, vpcId),
-			VPCPeeringConnections: describeVpcPeeringConnections(ctx, client, vpcId),
-			VPNConnections:        describeVpnConnections(ctx, client, vpcId),
-			RouteTables:           describeRouteTablesByVpc(ctx, client, vpcId),
+		for _, vpc := range output.Vpcs {
+			if vpc.VpcId == nil {
+				continue
+			}
+			vpcId := *vpc.VpcId
+			res <- VPCDetail{
+				VPC:  vpc,
+				Name: utils.GetNameFromTags(vpc.Tags),
+				Subnets: DescribeSubnetsByFilters(ctx, client, []types.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: []string{vpcId},
+					},
+				}),
+				ACLs: DescribeNetworkAclsByFilters(ctx, client, []types.Filter{
+					{
+						Name:   aws.String("vpc-id"),
+						Values: []string{vpcId},
+					},
+				}),
+				VPCEndpoints:          describeVpcEndpoints(ctx, client, vpcId),
+				VPCPeeringConnections: describeVpcPeeringConnections(ctx, client, vpcId),
+				VPNConnections:        describeVpnConnections(ctx, client, vpcId),
+				RouteTables:           describeRouteTablesByVpc(ctx, client, vpcId),
+			}
 		}
+		if output.NextToken == nil {
+			return nil
+		}
+		input.NextToken = output.NextToken
 	}
-
-	return nil
 }
 
 func DescribeVPCDetailsByFilters(ctx context.Context, c *ec2.Client, filters []types.Filter) (VPCDetails []VPCDetail) {
@@ -151,24 +156,6 @@ func DescribeSubnetsByFilters(ctx context.Context, c *ec2.Client, filters []type
 		subnets = append(subnets, page.Subnets...)
 	}
 	return subnets
-}
-
-func describeVpcs(ctx context.Context, c *ec2.Client) (vpcs []types.Vpc, err error) {
-	input := &ec2.DescribeVpcsInput{}
-	output, err := c.DescribeVpcs(ctx, input)
-	if err != nil {
-		return nil, err
-	}
-	vpcs = append(vpcs, output.Vpcs...)
-	for output.NextToken != nil {
-		input.NextToken = output.NextToken
-		output, err = c.DescribeVpcs(ctx, input)
-		if err != nil {
-			return nil, err
-		}
-		vpcs = append(vpcs, output.Vpcs...)
-	}
-	return vpcs, nil
 }
 
 func DescribeVpcsByFilters(ctx context.Context, c *ec2.Client, filters []types.Filter) (vpcs []types.Vpc) {

--- a/collector/aws/collector/ec2/vpc.go
+++ b/collector/aws/collector/ec2/vpc.go
@@ -70,53 +70,46 @@ type VPCDetail struct {
 	VPNConnections []types.VpnConnection
 }
 
+// GetVPCDetail streams each VPC detail incrementally; each VPC fans out
+// to six secondary describe calls (Subnets/ACLs/Endpoints/Peering/VPN/
+// RouteTables), so buffering them all before pushing would risk the
+// core-sdk consumer's 30s idle timeout (see schema/platform.go).
 func GetVPCDetail(ctx context.Context, iService schema.ServiceInterface, res chan<- any) error {
 	client := iService.(*collector.Services).EC2
 
-	VPCDetails, err := describeVPCDetails(ctx, client)
+	vpcs, err := describeVpcs(ctx, client)
 	if err != nil {
 		return err
 	}
 
-	for _, vpc := range VPCDetails {
-		res <- vpc
+	for _, vpc := range vpcs {
+		if vpc.VpcId == nil {
+			continue
+		}
+		vpcId := *vpc.VpcId
+		res <- VPCDetail{
+			VPC:  vpc,
+			Name: utils.GetNameFromTags(vpc.Tags),
+			Subnets: DescribeSubnetsByFilters(ctx, client, []types.Filter{
+				{
+					Name:   aws.String("vpc-id"),
+					Values: []string{vpcId},
+				},
+			}),
+			ACLs: DescribeNetworkAclsByFilters(ctx, client, []types.Filter{
+				{
+					Name:   aws.String("vpc-id"),
+					Values: []string{vpcId},
+				},
+			}),
+			VPCEndpoints:          describeVpcEndpoints(ctx, client, vpcId),
+			VPCPeeringConnections: describeVpcPeeringConnections(ctx, client, vpcId),
+			VPNConnections:        describeVpnConnections(ctx, client, vpcId),
+			RouteTables:           describeRouteTablesByVpc(ctx, client, vpcId),
+		}
 	}
 
 	return nil
-}
-
-// describeVPCDetails Describe VPCDetail with all your vpc.
-// // If you want to expand VPCDetail, expand this function.
-func describeVPCDetails(ctx context.Context, c *ec2.Client) (VPCDetails []VPCDetail, err error) {
-
-	vpcs, err := describeVpcs(ctx, c)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, vpc := range vpcs {
-		VPCDetails = append(VPCDetails, VPCDetail{
-			VPC:  vpc,
-			Name: utils.GetNameFromTags(vpc.Tags),
-			Subnets: DescribeSubnetsByFilters(ctx, c, []types.Filter{
-				{
-					Name:   aws.String("vpc-id"),
-					Values: []string{*vpc.VpcId},
-				},
-			}),
-			ACLs: DescribeNetworkAclsByFilters(ctx, c, []types.Filter{
-				{
-					Name:   aws.String("vpc-id"),
-					Values: []string{*vpc.VpcId},
-				},
-			}),
-			VPCEndpoints:          describeVpcEndpoints(ctx, c, *vpc.VpcId),
-			VPCPeeringConnections: describeVpcPeeringConnections(ctx, c, *vpc.VpcId),
-			VPNConnections:        describeVpnConnections(ctx, c, *vpc.VpcId),
-			RouteTables:           describeRouteTablesByVpc(ctx, c, *vpc.VpcId),
-		})
-	}
-	return VPCDetails, nil
 }
 
 func DescribeVPCDetailsByFilters(ctx context.Context, c *ec2.Client, filters []types.Filter) (VPCDetails []VPCDetail) {

--- a/collector/aws/collector/ecr/repository.go
+++ b/collector/aws/collector/ecr/repository.go
@@ -50,35 +50,25 @@ type RepositoryDetail struct {
 	RepositoryPolicy *string
 }
 
+// GetRepositoryDetail streams each ECR repository detail as its policy
+// fetch completes, avoiding the 30s consumer idle timeout in core-sdk
+// schema/platform.go when a region has many repositories.
 func GetRepositoryDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).ECR
-	repositoryDetails, err := describeRepositoryDetails(ctx, client)
+	repositories, err := describeRepositories(ctx, client)
 	if err != nil {
-		log.CtxLogger(ctx).Warn("describeRepositoryDetails error", zap.Error(err))
+		log.CtxLogger(ctx).Warn("describeRepositories error", zap.Error(err))
 		return err
 	}
-	for _, repositoryDetail := range repositoryDetails {
 
-		res <- repositoryDetail
+	for _, repository := range repositories {
+		res <- RepositoryDetail{
+			Repository:       repository,
+			RepositoryPolicy: getRepositoryPolicy(ctx, client, repository),
+		}
 	}
 
 	return nil
-}
-
-func describeRepositoryDetails(ctx context.Context, c *ecr.Client) (repositoryDetails []RepositoryDetail, err error) {
-	repositories, err := describeRepositories(ctx, c)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("describeRepositories error", zap.Error(err))
-		return nil, err
-	}
-	for _, repository := range repositories {
-		repositoryDetails = append(repositoryDetails, RepositoryDetail{
-			Repository:       repository,
-			RepositoryPolicy: getRepositoryPolicy(ctx, c, repository),
-		})
-	}
-
-	return repositoryDetails, nil
 }
 
 func getRepositoryPolicy(ctx context.Context, c *ecr.Client, repository types.Repository) *string {

--- a/collector/aws/collector/ecr/repository.go
+++ b/collector/aws/collector/ecr/repository.go
@@ -50,25 +50,31 @@ type RepositoryDetail struct {
 	RepositoryPolicy *string
 }
 
-// GetRepositoryDetail streams each ECR repository detail as its policy
-// fetch completes, avoiding the 30s consumer idle timeout in core-sdk
+// GetRepositoryDetail streams each ECR repository detail as the
+// DescribeRepositories pagination yields it and its policy fetch
+// completes, avoiding the 30s consumer idle timeout in core-sdk
 // schema/platform.go when a region has many repositories.
 func GetRepositoryDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).ECR
-	repositories, err := describeRepositories(ctx, client)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("describeRepositories error", zap.Error(err))
-		return err
-	}
 
-	for _, repository := range repositories {
-		res <- RepositoryDetail{
-			Repository:       repository,
-			RepositoryPolicy: getRepositoryPolicy(ctx, client, repository),
+	input := &ecr.DescribeRepositoriesInput{}
+	for {
+		output, err := client.DescribeRepositories(ctx, input)
+		if err != nil {
+			log.CtxLogger(ctx).Warn("DescribeRepositories error", zap.Error(err))
+			return err
 		}
+		for _, repository := range output.Repositories {
+			res <- RepositoryDetail{
+				Repository:       repository,
+				RepositoryPolicy: getRepositoryPolicy(ctx, client, repository),
+			}
+		}
+		if output.NextToken == nil {
+			return nil
+		}
+		input.NextToken = output.NextToken
 	}
-
-	return nil
 }
 
 func getRepositoryPolicy(ctx context.Context, c *ecr.Client, repository types.Repository) *string {
@@ -87,25 +93,4 @@ func getRepositoryPolicy(ctx context.Context, c *ecr.Client, repository types.Re
 	}
 
 	return nil
-}
-
-func describeRepositories(ctx context.Context, svc *ecr.Client) (repositories []types.Repository, err error) {
-	input := &ecr.DescribeRepositoriesInput{}
-	output, err := svc.DescribeRepositories(ctx, input)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("DescribeRepositories error", zap.Error(err))
-		return nil, err
-	}
-	repositories = append(repositories, output.Repositories...)
-	for output.NextToken != nil {
-		input.NextToken = output.NextToken
-		output, err = svc.DescribeRepositories(ctx, input)
-		if err != nil {
-			log.CtxLogger(ctx).Warn("DescribeRepositories error", zap.Error(err))
-			return nil, err
-		}
-		repositories = append(repositories, output.Repositories...)
-	}
-
-	return repositories, nil
 }

--- a/collector/aws/collector/ecs/cluster.go
+++ b/collector/aws/collector/ecs/cluster.go
@@ -26,6 +26,20 @@ import (
 	"go.uber.org/zap"
 )
 
+// ecsAPI is the narrow subset of the ecs client used by this collector,
+// declared so the streaming helper can be exercised with a fake in tests. The
+// signatures mirror the SDK exactly so the concrete *ecs.Client satisfies it,
+// including the paginator-client interfaces it feeds (ListClustersAPIClient,
+// ListServicesAPIClient, ListTasksAPIClient).
+type ecsAPI interface {
+	ListClusters(context.Context, *ecs.ListClustersInput, ...func(*ecs.Options)) (*ecs.ListClustersOutput, error)
+	DescribeClusters(context.Context, *ecs.DescribeClustersInput, ...func(*ecs.Options)) (*ecs.DescribeClustersOutput, error)
+	ListServices(context.Context, *ecs.ListServicesInput, ...func(*ecs.Options)) (*ecs.ListServicesOutput, error)
+	DescribeServices(context.Context, *ecs.DescribeServicesInput, ...func(*ecs.Options)) (*ecs.DescribeServicesOutput, error)
+	ListTasks(context.Context, *ecs.ListTasksInput, ...func(*ecs.Options)) (*ecs.ListTasksOutput, error)
+	DescribeTasks(context.Context, *ecs.DescribeTasksInput, ...func(*ecs.Options)) (*ecs.DescribeTasksOutput, error)
+}
+
 // GetClusterResource returns a Cluster Resource
 func GetClusterResource() schema.Resource {
 	return schema.Resource{
@@ -53,18 +67,22 @@ type ClusterDetail struct {
 func GetClusterDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).ECS
 
+	return streamClusters(ctx, client, res)
+}
+
+// streamClusters lists every cluster ARN, then describes them in batches of 100
+// (API limit) and streams each cluster as soon as its batch returns. Keeping the
+// per-cluster enrichment + push inside the batch loop ensures the consumer's 30s
+// idle timer in core-sdk schema/platform.go sees data within one DescribeClusters
+// round-trip, even on accounts with thousands of clusters. Mirrors the streaming
+// invariant established in 8295d1b / 5f3db2f.
+func streamClusters(ctx context.Context, client ecsAPI, res chan<- any) error {
 	clusterArns, err := listClusters(ctx, client)
 	if err != nil {
 		log.CtxLogger(ctx).Error("failed to list ecs clusters", zap.Error(err))
 		return err
 	}
 
-	// Describe clusters in batches of 100 (API limit) and stream each cluster
-	// as soon as its batch returns. Keeping the per-cluster enrichment + push
-	// inside the batch loop ensures the consumer's 30s idle timer in core-sdk
-	// schema/platform.go sees data within one DescribeClusters round-trip,
-	// even on accounts with thousands of clusters. Mirrors the streaming
-	// invariant established in 8295d1b / 5f3db2f.
 	for i := 0; i < len(clusterArns); i += 100 {
 		end := i + 100
 		if end > len(clusterArns) {
@@ -94,7 +112,7 @@ func GetClusterDetail(ctx context.Context, service schema.ServiceInterface, res 
 }
 
 // listClusters retrieves all ECS cluster ARNs in a region.
-func listClusters(ctx context.Context, c *ecs.Client) ([]string, error) {
+func listClusters(ctx context.Context, c ecsAPI) ([]string, error) {
 	var clusterArns []string
 	paginator := ecs.NewListClustersPaginator(c, &ecs.ListClustersInput{})
 	for paginator.HasMorePages() {
@@ -108,7 +126,7 @@ func listClusters(ctx context.Context, c *ecs.Client) ([]string, error) {
 }
 
 // describeClusters retrieves the details for a list of clusters.
-func describeClusters(ctx context.Context, c *ecs.Client, clusterArns []string) ([]types.Cluster, error) {
+func describeClusters(ctx context.Context, c ecsAPI, clusterArns []string) ([]types.Cluster, error) {
 	output, err := c.DescribeClusters(ctx, &ecs.DescribeClustersInput{Clusters: clusterArns, Include: []types.ClusterField{types.ClusterFieldTags, types.ClusterFieldSettings}})
 	if err != nil {
 		return nil, err
@@ -117,7 +135,7 @@ func describeClusters(ctx context.Context, c *ecs.Client, clusterArns []string) 
 }
 
 // listServices retrieves all ECS service ARNs in a cluster.
-func listServices(ctx context.Context, c *ecs.Client, clusterArn string) []types.Service {
+func listServices(ctx context.Context, c ecsAPI, clusterArn string) []types.Service {
 	var services []types.Service
 	paginator := ecs.NewListServicesPaginator(c, &ecs.ListServicesInput{Cluster: &clusterArn})
 	for paginator.HasMorePages() {
@@ -139,7 +157,7 @@ func listServices(ctx context.Context, c *ecs.Client, clusterArn string) []types
 }
 
 // listTasks retrieves all ECS task ARNs in a cluster.
-func listTasks(ctx context.Context, c *ecs.Client, clusterArn string) []types.Task {
+func listTasks(ctx context.Context, c ecsAPI, clusterArn string) []types.Task {
 	var tasks []types.Task
 	paginator := ecs.NewListTasksPaginator(c, &ecs.ListTasksInput{Cluster: &clusterArn})
 	for paginator.HasMorePages() {

--- a/collector/aws/collector/ecs/cluster.go
+++ b/collector/aws/collector/ecs/cluster.go
@@ -59,8 +59,12 @@ func GetClusterDetail(ctx context.Context, service schema.ServiceInterface, res 
 		return err
 	}
 
-	var clusters []types.Cluster
-	// Describe clusters in batches of 100, which is the API limit.
+	// Describe clusters in batches of 100 (API limit) and stream each cluster
+	// as soon as its batch returns. Keeping the per-cluster enrichment + push
+	// inside the batch loop ensures the consumer's 30s idle timer in core-sdk
+	// schema/platform.go sees data within one DescribeClusters round-trip,
+	// even on accounts with thousands of clusters. Mirrors the streaming
+	// invariant established in 8295d1b / 5f3db2f.
 	for i := 0; i < len(clusterArns); i += 100 {
 		end := i + 100
 		if end > len(clusterArns) {
@@ -73,19 +77,16 @@ func GetClusterDetail(ctx context.Context, service schema.ServiceInterface, res 
 			log.CtxLogger(ctx).Warn("failed to describe ecs clusters", zap.Error(err))
 			continue
 		}
-		clusters = append(clusters, describedClusters...)
-	}
 
-	for _, cluster := range clusters {
+		for _, cluster := range describedClusters {
+			services := listServices(ctx, client, *cluster.ClusterArn)
+			tasks := listTasks(ctx, client, *cluster.ClusterArn)
 
-		services := listServices(ctx, client, *cluster.ClusterArn)
-
-		tasks := listTasks(ctx, client, *cluster.ClusterArn)
-
-		res <- &ClusterDetail{
-			Cluster:  cluster,
-			Services: services,
-			Tasks:    tasks,
+			res <- &ClusterDetail{
+				Cluster:  cluster,
+				Services: services,
+				Tasks:    tasks,
+			}
 		}
 	}
 

--- a/collector/aws/collector/ecs/cluster_test.go
+++ b/collector/aws/collector/ecs/cluster_test.go
@@ -1,0 +1,212 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Streaming regression test for the "ARN list then batched describe" collector
+// form.
+//
+// Representative collector: ecs (this file). listClusters paginates ARNs, then
+// the ARNs are described in batches of 100 (API limit) and each described item
+// is enriched and pushed. No other AWS collector currently shares this form;
+// ecs is the sole representative.
+//
+// Two streaming links are asserted:
+//   - per-batch streaming: the first DescribeClusters batch is pushed before
+//     the next batch is described
+//     (TestStreamClustersStreamsFirstBatchBeforeNextBatchDescribe).
+//   - per-item enrich streaming: the first cluster is pushed once its own
+//     ListServices / ListTasks finish
+//     (TestStreamClustersPushesFirstResultBeforeAllClustersFinish).
+package ecs
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+)
+
+// fakeECSClient is a deterministic ecsAPI stand-in. ListClusters returns every
+// ARN in a single page; DescribeClusters echoes the requested ARNs back as
+// clusters. Either the per-batch DescribeClusters call or the per-cluster
+// ListServices enrichment call can be made to block after a configured number
+// of invocations, letting a test prove the first cluster is streamed before
+// later batches / clusters finish. DescribeServices / ListTasks / DescribeTasks
+// return empty so enrichment stays cheap.
+type fakeECSClient struct {
+	clusterArns []string
+
+	blockDescribeClustersAfter int // block DescribeClusters after this many calls (per-batch streaming)
+	unblockDescribe            chan struct{}
+
+	blockListServicesAfter int // block ListServices after this many calls (per-cluster streaming)
+	unblockServices        chan struct{}
+
+	mu                    sync.Mutex
+	listClustersCalls     int
+	describeClustersCalls int
+	listServicesCalls     int
+}
+
+func (f *fakeECSClient) ListClusters(context.Context, *ecs.ListClustersInput, ...func(*ecs.Options)) (*ecs.ListClustersOutput, error) {
+	f.mu.Lock()
+	f.listClustersCalls++
+	f.mu.Unlock()
+	return &ecs.ListClustersOutput{ClusterArns: f.clusterArns}, nil
+}
+
+func (f *fakeECSClient) DescribeClusters(ctx context.Context, input *ecs.DescribeClustersInput, _ ...func(*ecs.Options)) (*ecs.DescribeClustersOutput, error) {
+	f.mu.Lock()
+	f.describeClustersCalls++
+	call := f.describeClustersCalls
+	f.mu.Unlock()
+
+	if f.blockDescribeClustersAfter > 0 && call > f.blockDescribeClustersAfter && f.unblockDescribe != nil {
+		select {
+		case <-f.unblockDescribe:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	clusters := make([]types.Cluster, 0, len(input.Clusters))
+	for _, arn := range input.Clusters {
+		clusters = append(clusters, types.Cluster{
+			ClusterArn:  aws.String(arn),
+			ClusterName: aws.String(arn),
+		})
+	}
+	return &ecs.DescribeClustersOutput{Clusters: clusters}, nil
+}
+
+func (f *fakeECSClient) ListServices(ctx context.Context, _ *ecs.ListServicesInput, _ ...func(*ecs.Options)) (*ecs.ListServicesOutput, error) {
+	f.mu.Lock()
+	f.listServicesCalls++
+	call := f.listServicesCalls
+	f.mu.Unlock()
+
+	if f.blockListServicesAfter > 0 && call > f.blockListServicesAfter && f.unblockServices != nil {
+		select {
+		case <-f.unblockServices:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	return &ecs.ListServicesOutput{}, nil
+}
+
+func (f *fakeECSClient) DescribeServices(context.Context, *ecs.DescribeServicesInput, ...func(*ecs.Options)) (*ecs.DescribeServicesOutput, error) {
+	return &ecs.DescribeServicesOutput{}, nil
+}
+
+func (f *fakeECSClient) ListTasks(context.Context, *ecs.ListTasksInput, ...func(*ecs.Options)) (*ecs.ListTasksOutput, error) {
+	return &ecs.ListTasksOutput{}, nil
+}
+
+func (f *fakeECSClient) DescribeTasks(context.Context, *ecs.DescribeTasksInput, ...func(*ecs.Options)) (*ecs.DescribeTasksOutput, error) {
+	return &ecs.DescribeTasksOutput{}, nil
+}
+
+// Property (a) — enrich streaming: the first cluster is pushed once its own
+// ListServices / ListTasks calls return, without waiting for later clusters.
+// The second cluster's ListServices call is blocked, so a build-slice-then-push
+// regression would never deliver the first result.
+func TestStreamClustersPushesFirstResultBeforeAllClustersFinish(t *testing.T) {
+	unblockServices := make(chan struct{})
+	arns := makeClusterArns(5)
+	client := &fakeECSClient{
+		clusterArns:            arns,
+		blockListServicesAfter: 1,
+		unblockServices:        unblockServices,
+	}
+	res := make(chan any, len(arns))
+	done := make(chan error, 1)
+
+	go func() {
+		done <- streamClusters(context.Background(), client, res)
+	}()
+
+	detail := receiveFirstCluster(t, res)
+	if detail.Cluster.ClusterArn == nil {
+		t.Fatal("cluster arn is nil")
+	}
+	close(unblockServices)
+
+	if err := <-done; err != nil {
+		t.Fatalf("streamClusters returned error: %v", err)
+	}
+	if got := 1 + len(res); got != len(arns) {
+		t.Fatalf("streamed cluster count = %d, want %d", got, len(arns))
+	}
+}
+
+// Property (b) — per-batch streaming: the first DescribeClusters batch is pushed
+// before the second batch is described. With more than 100 ARNs the collector
+// describes in two batches; the second DescribeClusters call is blocked, so an
+// accumulate-all-batches-then-push regression would deadlock and never deliver
+// the first result.
+func TestStreamClustersStreamsFirstBatchBeforeNextBatchDescribe(t *testing.T) {
+	unblockDescribe := make(chan struct{})
+	arns := makeClusterArns(150) // 100 + 50 => two DescribeClusters batches
+	client := &fakeECSClient{
+		clusterArns:                arns,
+		blockDescribeClustersAfter: 1,
+		unblockDescribe:            unblockDescribe,
+	}
+	res := make(chan any, len(arns))
+	done := make(chan error, 1)
+
+	go func() {
+		done <- streamClusters(context.Background(), client, res)
+	}()
+
+	_ = receiveFirstCluster(t, res)
+	close(unblockDescribe)
+
+	if err := <-done; err != nil {
+		t.Fatalf("streamClusters returned error: %v", err)
+	}
+	if got := 1 + len(res); got != len(arns) {
+		t.Fatalf("streamed cluster count = %d, want %d", got, len(arns))
+	}
+}
+
+func receiveFirstCluster(t *testing.T, res <-chan any) *ClusterDetail {
+	t.Helper()
+	select {
+	case got := <-res:
+		detail, ok := got.(*ClusterDetail)
+		if !ok {
+			t.Fatalf("got %T, want *ClusterDetail", got)
+		}
+		return detail
+	case <-time.After(time.Second):
+		t.Fatal("collector did not stream first result before processing all clusters")
+	}
+	return nil
+}
+
+func makeClusterArns(count int) []string {
+	arns := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		arns = append(arns, fmt.Sprintf("arn:cluster-%d", i))
+	}
+	return arns
+}

--- a/collector/aws/collector/efs/filesystem.go
+++ b/collector/aws/collector/efs/filesystem.go
@@ -52,34 +52,25 @@ type FileSystemDetail struct {
 	FileSystemPolicy map[string]interface{}
 }
 
+// GetFileSystemDetail streams each EFS file system detail as its policy
+// fetch completes, avoiding the 30s consumer idle timeout in core-sdk
+// schema/platform.go when a region has many file systems.
 func GetFileSystemDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).EFS
 
-	fileSystemDetails, err := describeFileSystemDetails(ctx, client)
+	fileSystems, err := describeFileSystem(ctx, client)
 	if err != nil {
-		log.CtxLogger(ctx).Warn("describeFileSystemDetails error", zap.Error(err))
+		log.CtxLogger(ctx).Warn("describeFileSystem error", zap.Error(err))
 		return err
 	}
 
-	for _, fileSystemDetail := range fileSystemDetails {
-		res <- fileSystemDetail
+	for _, fileSystem := range fileSystems {
+		res <- FileSystemDetail{
+			FileSystem:       fileSystem,
+			FileSystemPolicy: getFileSystemPolicy(ctx, client, fileSystem),
+		}
 	}
 	return nil
-}
-
-func describeFileSystemDetails(ctx context.Context, c *efs.Client) (fileSystemDetails []FileSystemDetail, err error) {
-	fileSystems, err := describeFileSystem(ctx, c)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("describeFileSystem error", zap.Error(err))
-		return nil, err
-	}
-	for _, fileSystem := range fileSystems {
-		fileSystemDetails = append(fileSystemDetails, FileSystemDetail{
-			FileSystem:       fileSystem,
-			FileSystemPolicy: getFileSystemPolicy(ctx, c, fileSystem),
-		})
-	}
-	return fileSystemDetails, nil
 }
 
 func getFileSystemPolicy(ctx context.Context, c *efs.Client, fileSystem types.FileSystemDescription) (policy map[string]interface{}) {

--- a/collector/aws/collector/efs/filesystem.go
+++ b/collector/aws/collector/efs/filesystem.go
@@ -52,25 +52,31 @@ type FileSystemDetail struct {
 	FileSystemPolicy map[string]interface{}
 }
 
-// GetFileSystemDetail streams each EFS file system detail as its policy
-// fetch completes, avoiding the 30s consumer idle timeout in core-sdk
-// schema/platform.go when a region has many file systems.
+// GetFileSystemDetail streams each EFS file system detail as the
+// DescribeFileSystems pagination yields it and its policy fetch completes,
+// avoiding the 30s consumer idle timeout in core-sdk schema/platform.go
+// when a region has many file systems.
 func GetFileSystemDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).EFS
 
-	fileSystems, err := describeFileSystem(ctx, client)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("describeFileSystem error", zap.Error(err))
-		return err
-	}
-
-	for _, fileSystem := range fileSystems {
-		res <- FileSystemDetail{
-			FileSystem:       fileSystem,
-			FileSystemPolicy: getFileSystemPolicy(ctx, client, fileSystem),
+	input := &efs.DescribeFileSystemsInput{}
+	for {
+		output, err := client.DescribeFileSystems(ctx, input)
+		if err != nil {
+			log.CtxLogger(ctx).Warn("DescribeFileSystems error", zap.Error(err))
+			return err
 		}
+		for _, fileSystem := range output.FileSystems {
+			res <- FileSystemDetail{
+				FileSystem:       fileSystem,
+				FileSystemPolicy: getFileSystemPolicy(ctx, client, fileSystem),
+			}
+		}
+		if output.NextMarker == nil {
+			return nil
+		}
+		input.Marker = output.NextMarker
 	}
-	return nil
 }
 
 func getFileSystemPolicy(ctx context.Context, c *efs.Client, fileSystem types.FileSystemDescription) (policy map[string]interface{}) {
@@ -89,24 +95,4 @@ func getFileSystemPolicy(ctx context.Context, c *efs.Client, fileSystem types.Fi
 		return nil
 	}
 	return policy
-}
-
-func describeFileSystem(ctx context.Context, c *efs.Client) (fileSystems []types.FileSystemDescription, err error) {
-	input := &efs.DescribeFileSystemsInput{}
-	output, err := c.DescribeFileSystems(ctx, input)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("DescribeFileSystems error", zap.Error(err))
-		return nil, err
-	}
-	fileSystems = append(fileSystems, output.FileSystems...)
-	for output.NextMarker != nil {
-		input.Marker = output.NextMarker
-		output, err = c.DescribeFileSystems(ctx, input)
-		if err != nil {
-			log.CtxLogger(ctx).Warn("DescribeFileSystems error", zap.Error(err))
-			return nil, err
-		}
-		fileSystems = append(fileSystems, output.FileSystems...)
-	}
-	return fileSystems, nil
 }

--- a/collector/aws/collector/eks/cluster.go
+++ b/collector/aws/collector/eks/cluster.go
@@ -47,7 +47,11 @@ type ClusterDetail struct {
 	Cluster *types.Cluster
 }
 
-// GetClusterDetail fetches the details for all EKS clusters in a region.
+// GetClusterDetail fetches the details for all EKS clusters in a
+// region. Each detail is pushed to res as its per-cluster DescribeCluster
+// call finishes; do not refactor this into a build-slice-then-push
+// pattern, as that would risk the 30s consumer idle timeout in core-sdk
+// schema/platform.go (see commit 8295d1b).
 func GetClusterDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).EKS
 

--- a/collector/aws/collector/eks/cluster.go
+++ b/collector/aws/collector/eks/cluster.go
@@ -47,44 +47,32 @@ type ClusterDetail struct {
 	Cluster *types.Cluster
 }
 
-// GetClusterDetail fetches the details for all EKS clusters in a
-// region. Each detail is pushed to res as its per-cluster DescribeCluster
-// call finishes; do not refactor this into a build-slice-then-push
-// pattern, as that would risk the 30s consumer idle timeout in core-sdk
-// schema/platform.go (see commit 8295d1b).
+// GetClusterDetail fetches the details for all EKS clusters in a region.
+// The ListClusters pagination streams per page and each cluster is pushed
+// to res as its DescribeCluster call finishes; do not refactor back to a
+// build-slice-then-push pattern, as that would risk the 30s consumer idle
+// timeout in core-sdk schema/platform.go (see commit 8295d1b).
 func GetClusterDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).EKS
 
-	clusterNames, err := listClusters(ctx, client)
-	if err != nil {
-		log.CtxLogger(ctx).Error("failed to list eks clusters", zap.Error(err))
-		return err
-	}
-
-	for _, name := range clusterNames {
-		detail, err := describeCluster(ctx, client, name)
-		if err != nil {
-			log.CtxLogger(ctx).Error("failed to describe eks cluster", zap.Error(err))
-			continue
-		}
-		res <- detail
-	}
-
-	return nil
-}
-
-// listClusters retrieves all EKS cluster names in a region.
-func listClusters(ctx context.Context, c *eks.Client) ([]string, error) {
-	var clusterNames []string
-	paginator := eks.NewListClustersPaginator(c, &eks.ListClustersInput{})
+	paginator := eks.NewListClustersPaginator(client, &eks.ListClustersInput{})
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			return nil, err
+			log.CtxLogger(ctx).Error("failed to list eks clusters", zap.Error(err))
+			return err
 		}
-		clusterNames = append(clusterNames, page.Clusters...)
+		for _, name := range page.Clusters {
+			detail, err := describeCluster(ctx, client, name)
+			if err != nil {
+				log.CtxLogger(ctx).Error("failed to describe eks cluster", zap.Error(err))
+				continue
+			}
+			res <- detail
+		}
 	}
-	return clusterNames, nil
+
+	return nil
 }
 
 // describeCluster retrieves the details for a single cluster.

--- a/collector/aws/collector/elasticloadbalancing/elasticloadbalancingv2.go
+++ b/collector/aws/collector/elasticloadbalancing/elasticloadbalancingv2.go
@@ -30,6 +30,15 @@ import (
 	"go.uber.org/zap"
 )
 
+// elbv2API is the narrow subset of the elasticloadbalancingv2 client used by
+// this collector, declared so the streaming helpers can be exercised with a
+// fake in tests. The signatures mirror the SDK exactly so the concrete
+// *elasticloadbalancingv2.Client satisfies it.
+type elbv2API interface {
+	DescribeLoadBalancers(context.Context, *elasticloadbalancingv2.DescribeLoadBalancersInput, ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeLoadBalancersOutput, error)
+	DescribeListeners(context.Context, *elasticloadbalancingv2.DescribeListenersInput, ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeListenersOutput, error)
+}
+
 // GetELBResource returns a  ELB Resource
 // ELB is elasticloadbalancingv2
 func GetELBResource() schema.Resource {
@@ -87,31 +96,60 @@ func GetELBDetail(ctx context.Context, iService schema.ServiceInterface, res cha
 	elbClient := iService.(*collector.Services).ELB
 	ec2Client := iService.(*collector.Services).EC2
 
-	return forEachELB(ctx, elbClient, func(elb types.LoadBalancer) error {
-		listeners, err := describeELBListenersByLoadBalancerArn(ctx, elbClient, elb.LoadBalancerArn)
-		if err != nil {
-			log.CtxLogger(ctx).Warn("DescribeListeners error", zap.Error(err), zap.String("loadBalancerArn", aws.ToString(elb.LoadBalancerArn)))
-		}
-		var vpcDetails []ec2.VPCDetail
-		if elb.VpcId != nil {
-			vpcDetails = ec2.DescribeVPCDetailsByFilters(ctx, ec2Client, []types2.Filter{
+	return streamELBDetails(
+		ctx,
+		elbClient,
+		res,
+		func(ctx context.Context, elb types.LoadBalancer) []ec2.VPCDetail {
+			if elb.VpcId == nil {
+				return nil
+			}
+			return ec2.DescribeVPCDetailsByFilters(ctx, ec2Client, []types2.Filter{
 				{
 					Name:   aws.String("vpc-id"),
 					Values: []string{*elb.VpcId},
 				},
 			})
-		}
-		res <- ELBDetail{
-			ELB:       elb,
-			Listeners: listeners,
-			VPC:       vpcDetails,
-			SecurityGroups: ec2.DescribeSecurityGroupDetailsByFilters(ctx, ec2Client, []types2.Filter{
+		},
+		func(ctx context.Context, elb types.LoadBalancer) []ec2.SecurityGroupDetail {
+			return ec2.DescribeSecurityGroupDetailsByFilters(ctx, ec2Client, []types2.Filter{
 				{
 					Name:   aws.String("group-id"),
 					Values: elb.SecurityGroups,
 				},
-			}),
+			})
+		},
+	)
+}
+
+// streamELBDetails paginates DescribeLoadBalancers via forEachELB and pushes
+// each ELBDetail as soon as the page yields the LB and its listener call
+// returns. The VPC / SecurityGroup enrichment is injected so the streaming
+// behaviour can be exercised without an ec2 client; both callbacks are
+// non-nil in production and a nil callback simply skips that field.
+func streamELBDetails(
+	ctx context.Context,
+	c elbv2API,
+	res chan<- any,
+	describeVPCDetails func(context.Context, types.LoadBalancer) []ec2.VPCDetail,
+	describeSecurityGroupDetails func(context.Context, types.LoadBalancer) []ec2.SecurityGroupDetail,
+) error {
+	return forEachELB(ctx, c, func(elb types.LoadBalancer) error {
+		listeners, err := describeELBListenersByLoadBalancerArn(ctx, c, elb.LoadBalancerArn)
+		if err != nil {
+			log.CtxLogger(ctx).Warn("DescribeListeners error", zap.Error(err), zap.String("loadBalancerArn", aws.ToString(elb.LoadBalancerArn)))
 		}
+		detail := ELBDetail{
+			ELB:       elb,
+			Listeners: listeners,
+		}
+		if describeVPCDetails != nil {
+			detail.VPC = describeVPCDetails(ctx, elb)
+		}
+		if describeSecurityGroupDetails != nil {
+			detail.SecurityGroups = describeSecurityGroupDetails(ctx, elb)
+		}
+		res <- detail
 		return nil
 	})
 }
@@ -122,8 +160,14 @@ func GetELBDetail(ctx context.Context, iService schema.ServiceInterface, res cha
 func GetELBListenerDetail(ctx context.Context, iService schema.ServiceInterface, res chan<- any) error {
 	elbClient := iService.(*collector.Services).ELB
 
-	return forEachELB(ctx, elbClient, func(elb types.LoadBalancer) error {
-		listeners, err := describeELBListenersByLoadBalancerArn(ctx, elbClient, elb.LoadBalancerArn)
+	return streamELBListeners(ctx, elbClient, res)
+}
+
+// streamELBListeners paginates DescribeLoadBalancers via forEachELB and pushes
+// each LB's listeners as soon as the page yields the LB.
+func streamELBListeners(ctx context.Context, c elbv2API, res chan<- any) error {
+	return forEachELB(ctx, c, func(elb types.LoadBalancer) error {
+		listeners, err := describeELBListenersByLoadBalancerArn(ctx, c, elb.LoadBalancerArn)
 		if err != nil {
 			log.CtxLogger(ctx).Warn("DescribeListeners error", zap.Error(err), zap.String("loadBalancerArn", aws.ToString(elb.LoadBalancerArn)))
 			return nil
@@ -135,7 +179,7 @@ func GetELBListenerDetail(ctx context.Context, iService schema.ServiceInterface,
 	})
 }
 
-func describeELBListenersByLoadBalancerArn(ctx context.Context, c *elasticloadbalancingv2.Client, loadBalancerArn *string) (listeners []types.Listener, err error) {
+func describeELBListenersByLoadBalancerArn(ctx context.Context, c elbv2API, loadBalancerArn *string) (listeners []types.Listener, err error) {
 	if loadBalancerArn == nil {
 		return listeners, nil
 	}
@@ -163,7 +207,7 @@ func describeELBListenersByLoadBalancerArn(ctx context.Context, c *elasticloadba
 // load balancer as its page arrives, so callers stream per-LB instead of
 // buffering the whole region before the first push. Returns the first list
 // error encountered.
-func forEachELB(ctx context.Context, c *elasticloadbalancingv2.Client, handle func(types.LoadBalancer) error) error {
+func forEachELB(ctx context.Context, c elbv2API, handle func(types.LoadBalancer) error) error {
 	input := &elasticloadbalancingv2.DescribeLoadBalancersInput{
 		PageSize: aws.Int32(400),
 	}

--- a/collector/aws/collector/elasticloadbalancing/elasticloadbalancingv2.go
+++ b/collector/aws/collector/elasticloadbalancing/elasticloadbalancingv2.go
@@ -79,19 +79,15 @@ type ELBListenerDetail struct {
 	Listener types.Listener
 }
 
-// GetELBDetail streams each ELB detail as its secondary calls finish, so
-// the core-sdk consumer in schema/platform.go does not hit the 30s idle
-// timeout when a region has many load balancers.
+// GetELBDetail streams each ELB detail as the DescribeLoadBalancers
+// pagination yields it and its secondary calls finish, so the core-sdk
+// consumer in schema/platform.go does not hit the 30s idle timeout when a
+// region has many load balancers.
 func GetELBDetail(ctx context.Context, iService schema.ServiceInterface, res chan<- any) error {
 	elbClient := iService.(*collector.Services).ELB
 	ec2Client := iService.(*collector.Services).EC2
 
-	elbs, err := describeELBs(ctx, elbClient)
-	if err != nil {
-		return err
-	}
-
-	for _, elb := range elbs {
+	return forEachELB(ctx, elbClient, func(elb types.LoadBalancer) error {
 		listeners, err := describeELBListenersByLoadBalancerArn(ctx, elbClient, elb.LoadBalancerArn)
 		if err != nil {
 			log.CtxLogger(ctx).Warn("DescribeListeners error", zap.Error(err), zap.String("loadBalancerArn", aws.ToString(elb.LoadBalancerArn)))
@@ -116,33 +112,27 @@ func GetELBDetail(ctx context.Context, iService schema.ServiceInterface, res cha
 				},
 			}),
 		}
-	}
-
-	return nil
+		return nil
+	})
 }
 
-// GetELBListenerDetail streams each listener per LB. Same rationale as
+// GetELBListenerDetail streams each listener per LB as the
+// DescribeLoadBalancers pagination yields each LB. Same rationale as
 // GetELBDetail — incremental push keeps the consumer's idle timer warm.
 func GetELBListenerDetail(ctx context.Context, iService schema.ServiceInterface, res chan<- any) error {
 	elbClient := iService.(*collector.Services).ELB
 
-	elbs, err := describeELBs(ctx, elbClient)
-	if err != nil {
-		return err
-	}
-
-	for _, elb := range elbs {
+	return forEachELB(ctx, elbClient, func(elb types.LoadBalancer) error {
 		listeners, err := describeELBListenersByLoadBalancerArn(ctx, elbClient, elb.LoadBalancerArn)
 		if err != nil {
 			log.CtxLogger(ctx).Warn("DescribeListeners error", zap.Error(err), zap.String("loadBalancerArn", aws.ToString(elb.LoadBalancerArn)))
-			continue
+			return nil
 		}
 		for _, listener := range listeners {
 			res <- ELBListenerDetail{Listener: listener}
 		}
-	}
-
-	return nil
+		return nil
+	})
 }
 
 func describeELBListenersByLoadBalancerArn(ctx context.Context, c *elasticloadbalancingv2.Client, loadBalancerArn *string) (listeners []types.Listener, err error) {
@@ -169,24 +159,28 @@ func describeELBListenersByLoadBalancerArn(ctx context.Context, c *elasticloadba
 	return listeners, nil
 }
 
-func describeELBs(ctx context.Context, c *elasticloadbalancingv2.Client) (elbs []types.LoadBalancer, err error) {
+// forEachELB paginates DescribeLoadBalancers and invokes handle for each
+// load balancer as its page arrives, so callers stream per-LB instead of
+// buffering the whole region before the first push. Returns the first list
+// error encountered.
+func forEachELB(ctx context.Context, c *elasticloadbalancingv2.Client, handle func(types.LoadBalancer) error) error {
 	input := &elasticloadbalancingv2.DescribeLoadBalancersInput{
 		PageSize: aws.Int32(400),
 	}
-	output, err := c.DescribeLoadBalancers(ctx, input)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("DescribeLoadBalancers error", zap.Error(err))
-		return nil, err
-	}
-	elbs = append(elbs, output.LoadBalancers...)
-	for output.NextMarker != nil {
-		input.Marker = output.NextMarker
-		output, err = c.DescribeLoadBalancers(ctx, input)
+	for {
+		output, err := c.DescribeLoadBalancers(ctx, input)
 		if err != nil {
 			log.CtxLogger(ctx).Warn("DescribeLoadBalancers error", zap.Error(err))
-			return nil, err
+			return err
 		}
-		elbs = append(elbs, output.LoadBalancers...)
+		for _, elb := range output.LoadBalancers {
+			if err := handle(elb); err != nil {
+				return err
+			}
+		}
+		if output.NextMarker == nil {
+			return nil
+		}
+		input.Marker = output.NextMarker
 	}
-	return elbs, nil
 }

--- a/collector/aws/collector/elasticloadbalancing/elasticloadbalancingv2.go
+++ b/collector/aws/collector/elasticloadbalancing/elasticloadbalancingv2.go
@@ -19,7 +19,6 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	ec2_2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	types2 "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
@@ -80,43 +79,16 @@ type ELBListenerDetail struct {
 	Listener types.Listener
 }
 
+// GetELBDetail streams each ELB detail as its secondary calls finish, so
+// the core-sdk consumer in schema/platform.go does not hit the 30s idle
+// timeout when a region has many load balancers.
 func GetELBDetail(ctx context.Context, iService schema.ServiceInterface, res chan<- any) error {
 	elbClient := iService.(*collector.Services).ELB
 	ec2Client := iService.(*collector.Services).EC2
 
-	ELBDetails, err := describeELBDetails(ctx, elbClient, ec2Client)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("describeELBDetails error", zap.Error(err))
-		return err
-	}
-
-	for _, elb := range ELBDetails {
-		res <- elb
-	}
-
-	return nil
-}
-
-func GetELBListenerDetail(ctx context.Context, iService schema.ServiceInterface, res chan<- any) error {
-	elbClient := iService.(*collector.Services).ELB
-
-	listeners, err := describeELBListeners(ctx, elbClient)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("describeELBListeners error", zap.Error(err))
-		return err
-	}
-
-	for _, listener := range listeners {
-		res <- ELBListenerDetail{Listener: listener}
-	}
-
-	return nil
-}
-
-func describeELBDetails(ctx context.Context, elbClient *elasticloadbalancingv2.Client, ec2Client *ec2_2.Client) (ELBDetails []ELBDetail, err error) {
 	elbs, err := describeELBs(ctx, elbClient)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	for _, elb := range elbs {
@@ -124,40 +96,53 @@ func describeELBDetails(ctx context.Context, elbClient *elasticloadbalancingv2.C
 		if err != nil {
 			log.CtxLogger(ctx).Warn("DescribeListeners error", zap.Error(err), zap.String("loadBalancerArn", aws.ToString(elb.LoadBalancerArn)))
 		}
-		ELBDetails = append(ELBDetails, ELBDetail{
-			ELB:       elb,
-			Listeners: listeners,
-			VPC: ec2.DescribeVPCDetailsByFilters(ctx, ec2Client, []types2.Filter{
+		var vpcDetails []ec2.VPCDetail
+		if elb.VpcId != nil {
+			vpcDetails = ec2.DescribeVPCDetailsByFilters(ctx, ec2Client, []types2.Filter{
 				{
 					Name:   aws.String("vpc-id"),
 					Values: []string{*elb.VpcId},
 				},
-			}),
+			})
+		}
+		res <- ELBDetail{
+			ELB:       elb,
+			Listeners: listeners,
+			VPC:       vpcDetails,
 			SecurityGroups: ec2.DescribeSecurityGroupDetailsByFilters(ctx, ec2Client, []types2.Filter{
 				{
 					Name:   aws.String("group-id"),
 					Values: elb.SecurityGroups,
 				},
 			}),
-		})
+		}
 	}
-	return ELBDetails, nil
+
+	return nil
 }
 
-func describeELBListeners(ctx context.Context, c *elasticloadbalancingv2.Client) (listeners []types.Listener, err error) {
-	elbs, err := describeELBs(ctx, c)
+// GetELBListenerDetail streams each listener per LB. Same rationale as
+// GetELBDetail — incremental push keeps the consumer's idle timer warm.
+func GetELBListenerDetail(ctx context.Context, iService schema.ServiceInterface, res chan<- any) error {
+	elbClient := iService.(*collector.Services).ELB
+
+	elbs, err := describeELBs(ctx, elbClient)
 	if err != nil {
-		return nil, err
+		return err
 	}
+
 	for _, elb := range elbs {
-		lbListeners, err := describeELBListenersByLoadBalancerArn(ctx, c, elb.LoadBalancerArn)
+		listeners, err := describeELBListenersByLoadBalancerArn(ctx, elbClient, elb.LoadBalancerArn)
 		if err != nil {
 			log.CtxLogger(ctx).Warn("DescribeListeners error", zap.Error(err), zap.String("loadBalancerArn", aws.ToString(elb.LoadBalancerArn)))
 			continue
 		}
-		listeners = append(listeners, lbListeners...)
+		for _, listener := range listeners {
+			res <- ELBListenerDetail{Listener: listener}
+		}
 	}
-	return listeners, nil
+
+	return nil
 }
 
 func describeELBListenersByLoadBalancerArn(ctx context.Context, c *elasticloadbalancingv2.Client, loadBalancerArn *string) (listeners []types.Listener, err error) {

--- a/collector/aws/collector/elasticloadbalancing/elasticloadbalancingv2_test.go
+++ b/collector/aws/collector/elasticloadbalancing/elasticloadbalancingv2_test.go
@@ -1,0 +1,277 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Streaming regression test for the "manual pagination token" collector form.
+//
+// Representative collector: elasticloadbalancing / ELBv2 (this file). The
+// primary list call (DescribeLoadBalancers) is paginated by hand over a
+// next-token field, then each item is enriched and pushed. The same form — a
+// hand-rolled list loop over NextMarker / Marker / NextToken / IsTruncated /
+// ContinuationToken — backs these sibling collectors, covered here by
+// representation: ec2 (ec2/security_group/vpc), ecr, efs, fsx, rds,
+// route53/domain, s3, wafv2, iam.
+//
+// Two streaming links are asserted:
+//   - per-page list streaming: the first list page is pushed before the next
+//     page is fetched (TestStream*StreamsFirstPageBeforeNextPageList).
+//   - per-item enrich streaming: the first item is pushed once its own enrich
+//     calls finish, without waiting for later items
+//     (TestStream*PushesFirstResultBeforeAllLoadBalancersFinish).
+//
+// This representation covers the shared streaming skeleton, not each sibling's
+// own list-termination field or enrich sub-calls.
+package elasticloadbalancing
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+)
+
+// fakeELBV2Client is a deterministic elbv2API stand-in. DescribeLoadBalancers
+// returns either a single page (loadBalancers) or a sequence of pages (pages,
+// which takes precedence). Either the list call or the per-LB listener call can
+// be made to block after a configured number of invocations, letting a test
+// prove the first result is streamed before later work finishes.
+type fakeELBV2Client struct {
+	loadBalancers []types.LoadBalancer   // single-page mode
+	pages         [][]types.LoadBalancer // multi-page mode (takes precedence)
+
+	blockListenersAfter int // block DescribeListeners after this many calls
+	unblockListeners    chan struct{}
+
+	blockListAfter int // block DescribeLoadBalancers after this many calls
+	unblockList    chan struct{}
+
+	mu            sync.Mutex
+	listCalls     int
+	listenerCalls int
+}
+
+func (f *fakeELBV2Client) DescribeLoadBalancers(ctx context.Context, _ *elasticloadbalancingv2.DescribeLoadBalancersInput, _ ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeLoadBalancersOutput, error) {
+	f.mu.Lock()
+	f.listCalls++
+	call := f.listCalls
+	f.mu.Unlock()
+
+	if f.blockListAfter > 0 && call > f.blockListAfter && f.unblockList != nil {
+		select {
+		case <-f.unblockList:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	if len(f.pages) > 0 {
+		idx := call - 1
+		if idx >= len(f.pages) {
+			return &elasticloadbalancingv2.DescribeLoadBalancersOutput{}, nil
+		}
+		output := &elasticloadbalancingv2.DescribeLoadBalancersOutput{LoadBalancers: f.pages[idx]}
+		if idx < len(f.pages)-1 {
+			output.NextMarker = aws.String(fmt.Sprintf("page-%d", call))
+		}
+		return output, nil
+	}
+
+	return &elasticloadbalancingv2.DescribeLoadBalancersOutput{LoadBalancers: f.loadBalancers}, nil
+}
+
+func (f *fakeELBV2Client) DescribeListeners(ctx context.Context, input *elasticloadbalancingv2.DescribeListenersInput, _ ...func(*elasticloadbalancingv2.Options)) (*elasticloadbalancingv2.DescribeListenersOutput, error) {
+	f.mu.Lock()
+	f.listenerCalls++
+	call := f.listenerCalls
+	f.mu.Unlock()
+
+	if f.blockListenersAfter > 0 && call > f.blockListenersAfter && f.unblockListeners != nil {
+		select {
+		case <-f.unblockListeners:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	return &elasticloadbalancingv2.DescribeListenersOutput{
+		Listeners: []types.Listener{
+			{
+				ListenerArn:     aws.String(fmt.Sprintf("listener-%d", call)),
+				LoadBalancerArn: input.LoadBalancerArn,
+				Port:            aws.Int32(80),
+			},
+		},
+	}, nil
+}
+
+// Property (a) — enrich streaming: the first LB is pushed once its own listener
+// call returns, without waiting for later LBs' listener calls. The second
+// listener call is blocked, so a build-slice-then-push regression would never
+// deliver the first result.
+func TestStreamELBDetailsPushesFirstResultBeforeAllLoadBalancersFinish(t *testing.T) {
+	unblockListeners := make(chan struct{})
+	client := &fakeELBV2Client{
+		loadBalancers:       makeLoadBalancers(5),
+		blockListenersAfter: 1,
+		unblockListeners:    unblockListeners,
+	}
+	res := make(chan any, len(client.loadBalancers))
+	done := make(chan error, 1)
+
+	go func() {
+		done <- streamELBDetails(context.Background(), client, res, nil, nil)
+	}()
+
+	got := receiveFirstResult(t, res)
+	detail, ok := got.(ELBDetail)
+	if !ok {
+		t.Fatalf("got %T, want ELBDetail", got)
+	}
+	if len(detail.Listeners) != 1 {
+		t.Fatalf("listener count = %d, want 1", len(detail.Listeners))
+	}
+	close(unblockListeners)
+
+	if err := <-done; err != nil {
+		t.Fatalf("streamELBDetails returned error: %v", err)
+	}
+	if got := 1 + len(res); got != len(client.loadBalancers) {
+		t.Fatalf("streamed ELB detail count = %d, want %d", got, len(client.loadBalancers))
+	}
+}
+
+func TestStreamELBListenersPushesFirstResultBeforeAllLoadBalancersFinish(t *testing.T) {
+	unblockListeners := make(chan struct{})
+	client := &fakeELBV2Client{
+		loadBalancers:       makeLoadBalancers(5),
+		blockListenersAfter: 1,
+		unblockListeners:    unblockListeners,
+	}
+	res := make(chan any, len(client.loadBalancers))
+	done := make(chan error, 1)
+
+	go func() {
+		done <- streamELBListeners(context.Background(), client, res)
+	}()
+
+	got := receiveFirstResult(t, res)
+	detail, ok := got.(ELBListenerDetail)
+	if !ok {
+		t.Fatalf("got %T, want ELBListenerDetail", got)
+	}
+	if detail.Listener.ListenerArn == nil {
+		t.Fatal("listener arn is nil")
+	}
+	close(unblockListeners)
+
+	if err := <-done; err != nil {
+		t.Fatalf("streamELBListeners returned error: %v", err)
+	}
+	if got := 1 + len(res); got != len(client.loadBalancers) {
+		t.Fatalf("streamed ELB listener count = %d, want %d", got, len(client.loadBalancers))
+	}
+}
+
+// Property (b) — per-page streaming: the first DescribeLoadBalancers page is
+// pushed before the second page is even listed. The second list call is
+// blocked, so an accumulate-all-pages-then-push regression would deadlock and
+// never deliver the first result.
+func TestStreamELBListenersStreamsFirstPageBeforeNextPageList(t *testing.T) {
+	unblockList := make(chan struct{})
+	page1, page2 := makeLoadBalancers(2), makeLoadBalancers(3)
+	client := &fakeELBV2Client{
+		pages:          [][]types.LoadBalancer{page1, page2},
+		blockListAfter: 1,
+		unblockList:    unblockList,
+	}
+	total := len(page1) + len(page2)
+	res := make(chan any, total)
+	done := make(chan error, 1)
+
+	go func() {
+		done <- streamELBListeners(context.Background(), client, res)
+	}()
+
+	got := receiveFirstResult(t, res)
+	if _, ok := got.(ELBListenerDetail); !ok {
+		t.Fatalf("got %T, want ELBListenerDetail", got)
+	}
+	close(unblockList)
+
+	if err := <-done; err != nil {
+		t.Fatalf("streamELBListeners returned error: %v", err)
+	}
+	if got := 1 + len(res); got != total {
+		t.Fatalf("streamed ELB listener count = %d, want %d", got, total)
+	}
+}
+
+func TestStreamELBDetailsStreamsFirstPageBeforeNextPageList(t *testing.T) {
+	unblockList := make(chan struct{})
+	page1, page2 := makeLoadBalancers(2), makeLoadBalancers(3)
+	client := &fakeELBV2Client{
+		pages:          [][]types.LoadBalancer{page1, page2},
+		blockListAfter: 1,
+		unblockList:    unblockList,
+	}
+	total := len(page1) + len(page2)
+	res := make(chan any, total)
+	done := make(chan error, 1)
+
+	go func() {
+		done <- streamELBDetails(context.Background(), client, res, nil, nil)
+	}()
+
+	got := receiveFirstResult(t, res)
+	if _, ok := got.(ELBDetail); !ok {
+		t.Fatalf("got %T, want ELBDetail", got)
+	}
+	close(unblockList)
+
+	if err := <-done; err != nil {
+		t.Fatalf("streamELBDetails returned error: %v", err)
+	}
+	if got := 1 + len(res); got != total {
+		t.Fatalf("streamed ELB detail count = %d, want %d", got, total)
+	}
+}
+
+func receiveFirstResult(t *testing.T, res <-chan any) any {
+	t.Helper()
+	select {
+	case got := <-res:
+		return got
+	case <-time.After(time.Second):
+		t.Fatal("collector did not stream first result before processing all load balancers")
+	}
+	return nil
+}
+
+func makeLoadBalancers(count int) []types.LoadBalancer {
+	loadBalancers := make([]types.LoadBalancer, 0, count)
+	for i := 0; i < count; i++ {
+		loadBalancers = append(loadBalancers, types.LoadBalancer{
+			LoadBalancerArn:  aws.String(fmt.Sprintf("lb-%d", i)),
+			LoadBalancerName: aws.String(fmt.Sprintf("lb-%d", i)),
+			SecurityGroups:   []string{fmt.Sprintf("sg-%d", i)},
+			VpcId:            aws.String(fmt.Sprintf("vpc-%d", i)),
+		})
+	}
+	return loadBalancers
+}

--- a/collector/aws/collector/fsx/filesystem.go
+++ b/collector/aws/collector/fsx/filesystem.go
@@ -53,35 +53,25 @@ type FileSystemDetail struct {
 	Aliases []types.Alias
 }
 
+// GetFileSystemDetail streams each FSx file system detail as its
+// alias lookup completes, avoiding the 30s consumer idle timeout in
+// core-sdk schema/platform.go.
 func GetFileSystemDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).FSx
 
-	fileSystemDetails, err := describeFileSystemDetails(ctx, client)
+	fileSystems, err := describeFileSystem(ctx, client)
 	if err != nil {
-		log.CtxLogger(ctx).Warn("describeFileSystemDetails error", zap.Error(err))
+		log.CtxLogger(ctx).Warn("describeFileSystem error", zap.Error(err))
 		return err
 	}
 
-	for _, fileSystemDetail := range fileSystemDetails {
-		res <- fileSystemDetail
+	for _, fileSystem := range fileSystems {
+		res <- FileSystemDetail{
+			FileSystem: fileSystem,
+			Aliases:    describeFileSystemAliases(ctx, client, fileSystem),
+		}
 	}
 	return nil
-}
-
-func describeFileSystemDetails(ctx context.Context, c *fsx.Client) (fileSystemDetails []FileSystemDetail, err error) {
-
-	fileSystems, err := describeFileSystem(ctx, c)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("describeFileSystem error", zap.Error(err))
-		return nil, err
-	}
-	for _, fileSystem := range fileSystems {
-		fileSystemDetails = append(fileSystemDetails, FileSystemDetail{
-			FileSystem: fileSystem,
-			Aliases:    describeFileSystemAliases(ctx, c, fileSystem),
-		})
-	}
-	return fileSystemDetails, nil
 }
 
 func describeFileSystemAliases(ctx context.Context, c *fsx.Client, system types.FileSystem) (aliases []types.Alias) {

--- a/collector/aws/collector/fsx/filesystem.go
+++ b/collector/aws/collector/fsx/filesystem.go
@@ -53,25 +53,30 @@ type FileSystemDetail struct {
 	Aliases []types.Alias
 }
 
-// GetFileSystemDetail streams each FSx file system detail as its
-// alias lookup completes, avoiding the 30s consumer idle timeout in
-// core-sdk schema/platform.go.
+// GetFileSystemDetail streams each FSx file system detail as the
+// DescribeFileSystems pagination yields it and its alias lookup completes,
+// avoiding the 30s consumer idle timeout in core-sdk schema/platform.go.
 func GetFileSystemDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).FSx
 
-	fileSystems, err := describeFileSystem(ctx, client)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("describeFileSystem error", zap.Error(err))
-		return err
-	}
-
-	for _, fileSystem := range fileSystems {
-		res <- FileSystemDetail{
-			FileSystem: fileSystem,
-			Aliases:    describeFileSystemAliases(ctx, client, fileSystem),
+	input := &fsx.DescribeFileSystemsInput{}
+	for {
+		output, err := client.DescribeFileSystems(ctx, input)
+		if err != nil {
+			log.CtxLogger(ctx).Warn("describeFileSystems error", zap.Error(err))
+			return err
 		}
+		for _, fileSystem := range output.FileSystems {
+			res <- FileSystemDetail{
+				FileSystem: fileSystem,
+				Aliases:    describeFileSystemAliases(ctx, client, fileSystem),
+			}
+		}
+		if output.NextToken == nil {
+			return nil
+		}
+		input.NextToken = output.NextToken
 	}
-	return nil
 }
 
 func describeFileSystemAliases(ctx context.Context, c *fsx.Client, system types.FileSystem) (aliases []types.Alias) {
@@ -93,25 +98,4 @@ func describeFileSystemAliases(ctx context.Context, c *fsx.Client, system types.
 	}
 
 	return aliases
-}
-
-func describeFileSystem(ctx context.Context, c *fsx.Client) (fileSystems []types.FileSystem, err error) {
-	input := &fsx.DescribeFileSystemsInput{}
-	output, err := c.DescribeFileSystems(ctx, input)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("describeFileSystems error", zap.Error(err))
-		return nil, err
-	}
-	fileSystems = append(fileSystems, output.FileSystems...)
-	for output.NextToken != nil {
-		input.NextToken = output.NextToken
-		output, err = c.DescribeFileSystems(ctx, input)
-		if err != nil {
-			log.CtxLogger(ctx).Warn("describeFileSystems error", zap.Error(err))
-			return nil, err
-		}
-		fileSystems = append(fileSystems, output.FileSystems...)
-	}
-
-	return fileSystems, nil
 }

--- a/collector/aws/collector/iam/group.go
+++ b/collector/aws/collector/iam/group.go
@@ -50,35 +50,26 @@ type GroupDetail struct {
 	Users []types.User
 }
 
+// GetGroupDetail streams each IAM group detail as its user lookup
+// completes, avoiding the 30s consumer idle timeout in core-sdk
+// schema/platform.go when an account has many groups.
 func GetGroupDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).IAM
 
-	groupDetails, err := describeGroupDetails(ctx, client)
+	groups, err := getGroupAuthorizationDetails(ctx, client)
 	if err != nil {
-		log.CtxLogger(ctx).Warn("describeGroupDetails error", zap.Error(err))
+		log.CtxLogger(ctx).Warn("getGroupAuthorizationDetails error", zap.Error(err))
 		return err
 	}
 
-	for _, groupDetail := range groupDetails {
-		res <- groupDetail
-	}
-	return nil
-}
-
-func describeGroupDetails(ctx context.Context, c *iam.Client) (groupDetails []GroupDetail, err error) {
-	groups, err := getGroupAuthorizationDetails(ctx, c)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("getGroupAuthorizationDetails error", zap.Error(err))
-		return nil, err
-	}
 	for _, group := range groups {
-		groupDetails = append(groupDetails, GroupDetail{
+		res <- GroupDetail{
 			Group: group,
-			Users: getGroupUsers(ctx, c, group.GroupName),
-		})
+			Users: getGroupUsers(ctx, client, group.GroupName),
+		}
 	}
 
-	return groupDetails, nil
+	return nil
 }
 
 func getGroupUsers(ctx context.Context, c *iam.Client, groupName *string) []types.User {

--- a/collector/aws/collector/iam/group.go
+++ b/collector/aws/collector/iam/group.go
@@ -50,26 +50,35 @@ type GroupDetail struct {
 	Users []types.User
 }
 
-// GetGroupDetail streams each IAM group detail as its user lookup
-// completes, avoiding the 30s consumer idle timeout in core-sdk
-// schema/platform.go when an account has many groups.
+// GetGroupDetail streams each IAM group as the GetAccountAuthorizationDetails
+// pagination yields it and its user lookup completes, avoiding the 30s
+// consumer idle timeout in core-sdk schema/platform.go when an account has
+// many groups.
 func GetGroupDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).IAM
 
-	groups, err := getGroupAuthorizationDetails(ctx, client)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("getGroupAuthorizationDetails error", zap.Error(err))
-		return err
+	input := &iam.GetAccountAuthorizationDetailsInput{
+		Filter: []types.EntityType{
+			types.EntityTypeGroup,
+		},
 	}
-
-	for _, group := range groups {
-		res <- GroupDetail{
-			Group: group,
-			Users: getGroupUsers(ctx, client, group.GroupName),
+	for {
+		out, err := client.GetAccountAuthorizationDetails(ctx, input)
+		if err != nil {
+			log.CtxLogger(ctx).Warn("GetAccountAuthorizationDetails error", zap.Error(err))
+			return err
 		}
+		for _, group := range out.GroupDetailList {
+			res <- GroupDetail{
+				Group: group,
+				Users: getGroupUsers(ctx, client, group.GroupName),
+			}
+		}
+		if !out.IsTruncated {
+			return nil
+		}
+		input.Marker = out.Marker
 	}
-
-	return nil
 }
 
 func getGroupUsers(ctx context.Context, c *iam.Client, groupName *string) []types.User {
@@ -80,29 +89,4 @@ func getGroupUsers(ctx context.Context, c *iam.Client, groupName *string) []type
 		return nil
 	}
 	return getGroupOutput.Users
-}
-
-func getGroupAuthorizationDetails(ctx context.Context, c *iam.Client) (groupDetailList []types.GroupDetail, err error) {
-	input := &iam.GetAccountAuthorizationDetailsInput{
-		Filter: []types.EntityType{
-			types.EntityTypeGroup,
-		},
-	}
-	out, err := c.GetAccountAuthorizationDetails(ctx, input)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("GetAccountAuthorizationDetails error", zap.Error(err))
-		return nil, err
-	}
-	groupDetailList = append(groupDetailList, out.GroupDetailList...)
-	for out.IsTruncated {
-		input.Marker = out.Marker
-		out, err = c.GetAccountAuthorizationDetails(ctx, input)
-		if err != nil {
-			log.CtxLogger(ctx).Warn("GetAccountAuthorizationDetails error", zap.Error(err))
-			return nil, err
-		}
-		groupDetailList = append(groupDetailList, out.GroupDetailList...)
-	}
-
-	return groupDetailList, err
 }

--- a/collector/aws/collector/kms/key.go
+++ b/collector/aws/collector/kms/key.go
@@ -51,22 +51,25 @@ type KeyDetail struct {
 	Tags            []types.Tag
 }
 
-// GetKeyDetail fetches the details for all KMS keys in a region. Each
-// detail is pushed to res as its per-key Describe / Rotation / Policy /
-// Tags calls finish; do not refactor this into a build-slice-then-push
-// pattern, as that would risk the 30s consumer idle timeout in core-sdk
-// schema/platform.go (see commit 8295d1b).
+// GetKeyDetail fetches the details for all KMS keys in a region. The
+// ListKeys pagination streams per page and each key is pushed to res as
+// its Describe / Rotation / Policy / Tags calls finish; do not refactor
+// back to a build-slice-then-push pattern, as that would risk the 30s
+// consumer idle timeout in core-sdk schema/platform.go (see commit
+// 8295d1b).
 func GetKeyDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).KMS
 
-	keys, err := listKeys(ctx, client)
-	if err != nil {
-		log.CtxLogger(ctx).Error("failed to list kms keys", zap.Error(err))
-		return err
-	}
-
-	for _, key := range keys {
-		res <- describeKeyDetail(ctx, client, key.KeyId)
+	paginator := kms.NewListKeysPaginator(client, &kms.ListKeysInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			log.CtxLogger(ctx).Error("failed to list kms keys", zap.Error(err))
+			return err
+		}
+		for _, key := range page.Keys {
+			res <- describeKeyDetail(ctx, client, key.KeyId)
+		}
 	}
 
 	return nil
@@ -98,20 +101,6 @@ func describeKeyDetail(ctx context.Context, client *kms.Client, keyId *string) *
 		Policy:          policy,
 		Tags:            tags,
 	}
-}
-
-// listKeys retrieves all KMS keys in a region.
-func listKeys(ctx context.Context, c *kms.Client) ([]types.KeyListEntry, error) {
-	var keys []types.KeyListEntry
-	paginator := kms.NewListKeysPaginator(c, &kms.ListKeysInput{})
-	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, err
-		}
-		keys = append(keys, page.Keys...)
-	}
-	return keys, nil
 }
 
 // describeKey retrieves the metadata for a single KMS key.

--- a/collector/aws/collector/kms/key.go
+++ b/collector/aws/collector/kms/key.go
@@ -51,7 +51,11 @@ type KeyDetail struct {
 	Tags            []types.Tag
 }
 
-// GetKeyDetail fetches the details for all KMS keys in a region.
+// GetKeyDetail fetches the details for all KMS keys in a region. Each
+// detail is pushed to res as its per-key Describe / Rotation / Policy /
+// Tags calls finish; do not refactor this into a build-slice-then-push
+// pattern, as that would risk the 30s consumer idle timeout in core-sdk
+// schema/platform.go (see commit 8295d1b).
 func GetKeyDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).KMS
 

--- a/collector/aws/collector/lambda/function.go
+++ b/collector/aws/collector/lambda/function.go
@@ -52,23 +52,24 @@ type FunctionDetail struct {
 }
 
 // GetFunctionDetail fetches the details for all Lambda functions in a
-// region. Each detail is pushed to res as its per-function GetPolicy /
-// ListFunctionURLConfigs / ListTags calls finish; do not refactor this
-// into a build-slice-then-push pattern, as that would risk the 30s
-// consumer idle timeout in core-sdk schema/platform.go (see commit
-// 8295d1b).
+// region. The ListFunctions pagination streams per page and each function
+// is pushed to res as its GetPolicy / ListFunctionURLConfigs / ListTags
+// calls finish; do not refactor back to a build-slice-then-push pattern,
+// as that would risk the 30s consumer idle timeout in core-sdk
+// schema/platform.go (see commit 8295d1b).
 func GetFunctionDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).Lambda
 
-	functions, err := listFunctions(ctx, client)
-	if err != nil {
-		log.CtxLogger(ctx).Error("failed to list lambda functions", zap.Error(err))
-		return err
-	}
-
-	for _, function := range functions {
-		functionDetail := describeFunctionDetail(ctx, client, function)
-		res <- functionDetail
+	paginator := lambda.NewListFunctionsPaginator(client, &lambda.ListFunctionsInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			log.CtxLogger(ctx).Error("failed to list lambda functions", zap.Error(err))
+			return err
+		}
+		for _, function := range page.Functions {
+			res <- describeFunctionDetail(ctx, client, function)
+		}
 	}
 
 	return nil
@@ -90,20 +91,6 @@ func describeFunctionDetail(ctx context.Context, client *lambda.Client, function
 		URLConfigs: urlConfigs,
 		Tags:       tags,
 	}
-}
-
-// listFunctions retrieves all Lambda functions in a region.
-func listFunctions(ctx context.Context, c *lambda.Client) ([]types.FunctionConfiguration, error) {
-	var functions []types.FunctionConfiguration
-	paginator := lambda.NewListFunctionsPaginator(c, &lambda.ListFunctionsInput{})
-	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, err
-		}
-		functions = append(functions, page.Functions...)
-	}
-	return functions, nil
 }
 
 // getPolicy retrieves the resource-based policy for a function.

--- a/collector/aws/collector/lambda/function.go
+++ b/collector/aws/collector/lambda/function.go
@@ -27,6 +27,18 @@ import (
 	"go.uber.org/zap"
 )
 
+// lambdaAPI is the narrow subset of the lambda client used by this collector,
+// declared so the streaming helper can be exercised with a fake in tests. The
+// signatures mirror the SDK exactly so the concrete *lambda.Client satisfies
+// it, including the paginator-client interfaces ListFunctionsAPIClient and
+// ListFunctionUrlConfigsAPIClient.
+type lambdaAPI interface {
+	ListFunctions(context.Context, *lambda.ListFunctionsInput, ...func(*lambda.Options)) (*lambda.ListFunctionsOutput, error)
+	GetPolicy(context.Context, *lambda.GetPolicyInput, ...func(*lambda.Options)) (*lambda.GetPolicyOutput, error)
+	ListFunctionUrlConfigs(context.Context, *lambda.ListFunctionUrlConfigsInput, ...func(*lambda.Options)) (*lambda.ListFunctionUrlConfigsOutput, error)
+	ListTags(context.Context, *lambda.ListTagsInput, ...func(*lambda.Options)) (*lambda.ListTagsOutput, error)
+}
+
 // GetFunctionResource returns a Function Resource
 func GetFunctionResource() schema.Resource {
 	return schema.Resource{
@@ -51,15 +63,19 @@ type FunctionDetail struct {
 	Tags       map[string]string
 }
 
-// GetFunctionDetail fetches the details for all Lambda functions in a
-// region. The ListFunctions pagination streams per page and each function
-// is pushed to res as its GetPolicy / ListFunctionURLConfigs / ListTags
-// calls finish; do not refactor back to a build-slice-then-push pattern,
-// as that would risk the 30s consumer idle timeout in core-sdk
-// schema/platform.go (see commit 8295d1b).
+// GetFunctionDetail fetches the details for all Lambda functions in a region.
 func GetFunctionDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).Lambda
 
+	return streamFunctions(ctx, client, res)
+}
+
+// streamFunctions paginates ListFunctions and pushes each function to res as
+// its GetPolicy / ListFunctionURLConfigs / ListTags calls finish, both per
+// page and per function; do not refactor back to a build-slice-then-push
+// pattern, as that would risk the 30s consumer idle timeout in core-sdk
+// schema/platform.go (see commit 8295d1b).
+func streamFunctions(ctx context.Context, client lambdaAPI, res chan<- any) error {
 	paginator := lambda.NewListFunctionsPaginator(client, &lambda.ListFunctionsInput{})
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
@@ -76,7 +92,7 @@ func GetFunctionDetail(ctx context.Context, service schema.ServiceInterface, res
 }
 
 // describeFunctionDetail fetches all details for a single function.
-func describeFunctionDetail(ctx context.Context, client *lambda.Client, function types.FunctionConfiguration) *FunctionDetail {
+func describeFunctionDetail(ctx context.Context, client lambdaAPI, function types.FunctionConfiguration) *FunctionDetail {
 	var policy map[string]interface{}
 	var urlConfigs []types.FunctionUrlConfig
 	var tags map[string]string
@@ -94,7 +110,7 @@ func describeFunctionDetail(ctx context.Context, client *lambda.Client, function
 }
 
 // getPolicy retrieves the resource-based policy for a function.
-func getPolicy(ctx context.Context, c *lambda.Client, functionName *string) (map[string]interface{}, error) {
+func getPolicy(ctx context.Context, c lambdaAPI, functionName *string) (map[string]interface{}, error) {
 	output, err := c.GetPolicy(ctx, &lambda.GetPolicyInput{FunctionName: functionName})
 	if err != nil {
 		// It's common for a function not to have a policy, so we just log it as debug.
@@ -112,7 +128,7 @@ func getPolicy(ctx context.Context, c *lambda.Client, functionName *string) (map
 }
 
 // listFunctionURLConfigs retrieves the URL configs for a function.
-func listFunctionURLConfigs(ctx context.Context, c *lambda.Client, functionName *string) ([]types.FunctionUrlConfig, error) {
+func listFunctionURLConfigs(ctx context.Context, c lambdaAPI, functionName *string) ([]types.FunctionUrlConfig, error) {
 	var urlConfigs []types.FunctionUrlConfig
 	paginator := lambda.NewListFunctionUrlConfigsPaginator(c, &lambda.ListFunctionUrlConfigsInput{FunctionName: functionName})
 	for paginator.HasMorePages() {
@@ -127,7 +143,7 @@ func listFunctionURLConfigs(ctx context.Context, c *lambda.Client, functionName 
 }
 
 // listTags retrieves all tags for a function.
-func listTags(ctx context.Context, c *lambda.Client, functionArn *string) (map[string]string, error) {
+func listTags(ctx context.Context, c lambdaAPI, functionArn *string) (map[string]string, error) {
 	output, err := c.ListTags(ctx, &lambda.ListTagsInput{Resource: functionArn})
 	if err != nil {
 		log.CtxLogger(ctx).Warn("failed to list lambda tags", zap.String("functionArn", *functionArn), zap.Error(err))

--- a/collector/aws/collector/lambda/function.go
+++ b/collector/aws/collector/lambda/function.go
@@ -51,7 +51,12 @@ type FunctionDetail struct {
 	Tags       map[string]string
 }
 
-// GetFunctionDetail fetches the details for all Lambda functions in a region.
+// GetFunctionDetail fetches the details for all Lambda functions in a
+// region. Each detail is pushed to res as its per-function GetPolicy /
+// ListFunctionURLConfigs / ListTags calls finish; do not refactor this
+// into a build-slice-then-push pattern, as that would risk the 30s
+// consumer idle timeout in core-sdk schema/platform.go (see commit
+// 8295d1b).
 func GetFunctionDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).Lambda
 

--- a/collector/aws/collector/lambda/function_test.go
+++ b/collector/aws/collector/lambda/function_test.go
@@ -1,0 +1,210 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Streaming regression test for the "SDK paginator" collector form.
+//
+// Representative collector: lambda (this file). The primary list call is driven
+// by an aws-sdk-go-v2 NewXPaginator. The same form backs these sibling
+// collectors, covered here by representation: acm, eks, kms, secretsmanager,
+// sns, sqs, route53/resourcerecordset. (A few, e.g. route53 hosted zones, page
+// their outermost list with a manual token but keep the same per-page +
+// per-item streaming shape.)
+//
+// Two streaming links are asserted:
+//   - per-page list streaming: the first ListFunctions page is pushed before
+//     the next page is fetched
+//     (TestStreamFunctionsStreamsFirstPageBeforeNextPageList).
+//   - per-item enrich streaming: the first function is pushed once its own
+//     GetPolicy / ListFunctionURLConfigs / ListTags finish
+//     (TestStreamFunctionsPushesFirstResultBeforeAllFunctionsFinish).
+//
+// This representation covers the shared streaming skeleton, not each sibling's
+// own paginator input/termination or enrich sub-calls.
+package lambda
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
+)
+
+// fakeLambdaClient is a deterministic lambdaAPI stand-in. ListFunctions returns
+// either a single page (functions) or a sequence of pages (pages, which takes
+// precedence). Either the ListFunctions call or the per-function ListTags call
+// can be made to block after a configured number of invocations, letting a test
+// prove the first function is streamed before later work finishes.
+type fakeLambdaClient struct {
+	functions []types.FunctionConfiguration   // single-page mode
+	pages     [][]types.FunctionConfiguration // multi-page mode (takes precedence)
+
+	blockListFunctionsAfter int // block ListFunctions after this many calls
+	unblockList             chan struct{}
+
+	blockListTagsAfter int // block ListTags after this many calls
+	unblockTags        chan struct{}
+
+	mu                 sync.Mutex
+	listFunctionsCalls int
+	listTagsCalls      int
+}
+
+func (f *fakeLambdaClient) ListFunctions(ctx context.Context, _ *lambda.ListFunctionsInput, _ ...func(*lambda.Options)) (*lambda.ListFunctionsOutput, error) {
+	f.mu.Lock()
+	f.listFunctionsCalls++
+	call := f.listFunctionsCalls
+	f.mu.Unlock()
+
+	if f.blockListFunctionsAfter > 0 && call > f.blockListFunctionsAfter && f.unblockList != nil {
+		select {
+		case <-f.unblockList:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	if len(f.pages) > 0 {
+		idx := call - 1
+		if idx >= len(f.pages) {
+			return &lambda.ListFunctionsOutput{}, nil
+		}
+		output := &lambda.ListFunctionsOutput{Functions: f.pages[idx]}
+		if idx < len(f.pages)-1 {
+			output.NextMarker = aws.String(fmt.Sprintf("page-%d", call))
+		}
+		return output, nil
+	}
+
+	return &lambda.ListFunctionsOutput{Functions: f.functions}, nil
+}
+
+func (f *fakeLambdaClient) GetPolicy(context.Context, *lambda.GetPolicyInput, ...func(*lambda.Options)) (*lambda.GetPolicyOutput, error) {
+	return &lambda.GetPolicyOutput{Policy: aws.String("{}")}, nil
+}
+
+func (f *fakeLambdaClient) ListFunctionUrlConfigs(context.Context, *lambda.ListFunctionUrlConfigsInput, ...func(*lambda.Options)) (*lambda.ListFunctionUrlConfigsOutput, error) {
+	return &lambda.ListFunctionUrlConfigsOutput{}, nil
+}
+
+func (f *fakeLambdaClient) ListTags(ctx context.Context, _ *lambda.ListTagsInput, _ ...func(*lambda.Options)) (*lambda.ListTagsOutput, error) {
+	f.mu.Lock()
+	f.listTagsCalls++
+	call := f.listTagsCalls
+	f.mu.Unlock()
+
+	if f.blockListTagsAfter > 0 && call > f.blockListTagsAfter && f.unblockTags != nil {
+		select {
+		case <-f.unblockTags:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	return &lambda.ListTagsOutput{Tags: map[string]string{"k": "v"}}, nil
+}
+
+// Property (a) — enrich streaming: the first function is pushed once its own
+// GetPolicy / ListFunctionURLConfigs / ListTags calls return, without waiting
+// for later functions. The second function's ListTags call is blocked, so a
+// build-slice-then-push regression would never deliver the first result.
+func TestStreamFunctionsPushesFirstResultBeforeAllFunctionsFinish(t *testing.T) {
+	unblockTags := make(chan struct{})
+	client := &fakeLambdaClient{
+		functions:          makeFunctions(5),
+		blockListTagsAfter: 1,
+		unblockTags:        unblockTags,
+	}
+	res := make(chan any, len(client.functions))
+	done := make(chan error, 1)
+
+	go func() {
+		done <- streamFunctions(context.Background(), client, res)
+	}()
+
+	detail := receiveFirstFunction(t, res)
+	if detail.Function.FunctionName == nil {
+		t.Fatal("function name is nil")
+	}
+	close(unblockTags)
+
+	if err := <-done; err != nil {
+		t.Fatalf("streamFunctions returned error: %v", err)
+	}
+	if got := 1 + len(res); got != len(client.functions) {
+		t.Fatalf("streamed function count = %d, want %d", got, len(client.functions))
+	}
+}
+
+// Property (b) — per-page streaming: the first ListFunctions page is pushed
+// before the second page is even listed. The second list call is blocked, so
+// an accumulate-all-pages-then-push regression would deadlock and never deliver
+// the first result.
+func TestStreamFunctionsStreamsFirstPageBeforeNextPageList(t *testing.T) {
+	unblockList := make(chan struct{})
+	page1, page2 := makeFunctions(2), makeFunctions(3)
+	client := &fakeLambdaClient{
+		pages:                   [][]types.FunctionConfiguration{page1, page2},
+		blockListFunctionsAfter: 1,
+		unblockList:             unblockList,
+	}
+	total := len(page1) + len(page2)
+	res := make(chan any, total)
+	done := make(chan error, 1)
+
+	go func() {
+		done <- streamFunctions(context.Background(), client, res)
+	}()
+
+	_ = receiveFirstFunction(t, res)
+	close(unblockList)
+
+	if err := <-done; err != nil {
+		t.Fatalf("streamFunctions returned error: %v", err)
+	}
+	if got := 1 + len(res); got != total {
+		t.Fatalf("streamed function count = %d, want %d", got, total)
+	}
+}
+
+func receiveFirstFunction(t *testing.T, res <-chan any) *FunctionDetail {
+	t.Helper()
+	select {
+	case got := <-res:
+		detail, ok := got.(*FunctionDetail)
+		if !ok {
+			t.Fatalf("got %T, want *FunctionDetail", got)
+		}
+		return detail
+	case <-time.After(time.Second):
+		t.Fatal("collector did not stream first result before processing all functions")
+	}
+	return nil
+}
+
+func makeFunctions(count int) []types.FunctionConfiguration {
+	functions := make([]types.FunctionConfiguration, 0, count)
+	for i := 0; i < count; i++ {
+		functions = append(functions, types.FunctionConfiguration{
+			FunctionName: aws.String(fmt.Sprintf("fn-%d", i)),
+			FunctionArn:  aws.String(fmt.Sprintf("arn:fn-%d", i)),
+		})
+	}
+	return functions
+}

--- a/collector/aws/collector/macie/finding.go
+++ b/collector/aws/collector/macie/finding.go
@@ -49,51 +49,41 @@ type FindingDetail struct {
 	Tags    map[string]string
 }
 
-// GetFindingDetail fetches the details for all Macie findings in a region.
+// GetFindingDetail streams each Macie finding detail page-by-page,
+// pushing each batch of findings to the channel as soon as the
+// per-page GetFindings call returns. This avoids the 30s consumer
+// idle timeout in core-sdk schema/platform.go that would otherwise
+// fire when the account has many pages of findings (the per-page
+// secondary GetFindings call accumulates serial latency).
 func GetFindingDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).Macie
 
-	findings, err := listFindings(ctx, client)
-	if err != nil {
-		log.CtxLogger(ctx).Error("failed to list Macie findings", zap.Error(err))
-		return err
-	}
-
-	for _, finding := range findings {
-		findingDetail := describeFindingDetail(ctx, client, finding)
-		res <- findingDetail
-	}
-
-	return nil
-}
-
-// listFindings retrieves all Macie findings in a region.
-func listFindings(ctx context.Context, c *macie2.Client) ([]types.Finding, error) {
-	var findings []types.Finding
 	input := &macie2.ListFindingsInput{
 		MaxResults: aws.Int32(50),
 	}
-
-	paginator := macie2.NewListFindingsPaginator(c, input)
+	paginator := macie2.NewListFindingsPaginator(client, input)
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			return nil, err
+			log.CtxLogger(ctx).Error("failed to list Macie findings", zap.Error(err))
+			return err
 		}
-
-		// Get detailed finding information
-		if len(page.FindingIds) > 0 {
-			getInput := &macie2.GetFindingsInput{
-				FindingIds: page.FindingIds,
-			}
-			getOutput, err := c.GetFindings(ctx, getInput)
-			if err != nil {
-				return nil, err
-			}
-			findings = append(findings, getOutput.Findings...)
+		if len(page.FindingIds) == 0 {
+			continue
+		}
+		getOutput, err := client.GetFindings(ctx, &macie2.GetFindingsInput{
+			FindingIds: page.FindingIds,
+		})
+		if err != nil {
+			log.CtxLogger(ctx).Warn("failed to get Macie findings", zap.Error(err))
+			continue
+		}
+		for _, finding := range getOutput.Findings {
+			res <- describeFindingDetail(ctx, client, finding)
 		}
 	}
-	return findings, nil
+
+	return nil
 }
 
 // describeFindingDetail fetches all details for a single finding.

--- a/collector/aws/collector/opensearch/domain.go
+++ b/collector/aws/collector/opensearch/domain.go
@@ -47,7 +47,11 @@ type DomainDetail struct {
 	DomainStatus *types.DomainStatus
 }
 
-// GetDomainDetail fetches the details for all OpenSearch domains in a region.
+// GetDomainDetail fetches the details for all OpenSearch domains in a
+// region. Each detail is pushed to res as its per-domain DescribeDomain
+// call finishes; do not refactor this into a build-slice-then-push
+// pattern, as that would risk the 30s consumer idle timeout in core-sdk
+// schema/platform.go (see commit 8295d1b).
 func GetDomainDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).OpenSearch
 

--- a/collector/aws/collector/opensearch/domain.go
+++ b/collector/aws/collector/opensearch/domain.go
@@ -26,6 +26,15 @@ import (
 	"go.uber.org/zap"
 )
 
+// opensearchAPI is the narrow subset of the opensearch client used by this
+// collector, declared so the streaming helper can be exercised with a fake in
+// tests. The signatures mirror the SDK exactly so the concrete
+// *opensearch.Client satisfies it.
+type opensearchAPI interface {
+	ListDomainNames(context.Context, *opensearch.ListDomainNamesInput, ...func(*opensearch.Options)) (*opensearch.ListDomainNamesOutput, error)
+	DescribeDomain(context.Context, *opensearch.DescribeDomainInput, ...func(*opensearch.Options)) (*opensearch.DescribeDomainOutput, error)
+}
+
 // GetDomainResource returns AWS OpenSearch domain resource definition
 func GetDomainResource() schema.Resource {
 	return schema.Resource{
@@ -47,14 +56,21 @@ type DomainDetail struct {
 	DomainStatus *types.DomainStatus
 }
 
-// GetDomainDetail fetches the details for all OpenSearch domains in a
-// region. Each detail is pushed to res as its per-domain DescribeDomain
-// call finishes; do not refactor this into a build-slice-then-push
-// pattern, as that would risk the 30s consumer idle timeout in core-sdk
-// schema/platform.go (see commit 8295d1b).
+// GetDomainDetail fetches the details for all OpenSearch domains in a region.
 func GetDomainDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).OpenSearch
 
+	return streamDomains(ctx, client, res)
+}
+
+// streamDomains lists every OpenSearch domain (ListDomainNames returns them all
+// in one shot — this API has no pagination) and pushes each DomainDetail as its
+// per-domain DescribeDomain call finishes; do not refactor into a
+// build-slice-then-push pattern, as that would risk the 30s consumer idle
+// timeout in core-sdk schema/platform.go (see commit 8295d1b). A domain whose
+// DescribeDomain fails is skipped (describeDomain returns nil) so one failure
+// neither panics nor aborts the rest of the region.
+func streamDomains(ctx context.Context, client opensearchAPI, res chan<- any) error {
 	domains, err := listDomains(ctx, client)
 	if err != nil {
 		log.CtxLogger(ctx).Error("failed to list OpenSearch domains", zap.Error(err))
@@ -77,7 +93,7 @@ func GetDomainDetail(ctx context.Context, service schema.ServiceInterface, res c
 }
 
 // listDomains retrieves all OpenSearch domains in a region.
-func listDomains(ctx context.Context, c *opensearch.Client) ([]types.DomainInfo, error) {
+func listDomains(ctx context.Context, c opensearchAPI) ([]types.DomainInfo, error) {
 	input := &opensearch.ListDomainNamesInput{}
 
 	output, err := c.ListDomainNames(ctx, input)
@@ -89,7 +105,7 @@ func listDomains(ctx context.Context, c *opensearch.Client) ([]types.DomainInfo,
 }
 
 // describeDomain fetches all details for a single domain.
-func describeDomain(ctx context.Context, client *opensearch.Client, domain types.DomainInfo) *opensearch.DescribeDomainOutput {
+func describeDomain(ctx context.Context, client opensearchAPI, domain types.DomainInfo) *opensearch.DescribeDomainOutput {
 	// Get detailed domain information
 	describeInput := &opensearch.DescribeDomainInput{
 		DomainName: domain.DomainName,

--- a/collector/aws/collector/opensearch/domain.go
+++ b/collector/aws/collector/opensearch/domain.go
@@ -63,6 +63,12 @@ func GetDomainDetail(ctx context.Context, service schema.ServiceInterface, res c
 
 	for _, domain := range domains {
 		describeOutput := describeDomain(ctx, client, domain)
+		// describeDomain returns nil when DescribeDomain fails; skip rather
+		// than dereference (a single failed domain must not panic and abort
+		// the whole region's collection).
+		if describeOutput == nil {
+			continue
+		}
 		res <- DomainDetail{
 			DomainStatus: describeOutput.DomainStatus,
 		}

--- a/collector/aws/collector/opensearch/domain_test.go
+++ b/collector/aws/collector/opensearch/domain_test.go
@@ -1,0 +1,182 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Streaming regression test for the "un-paginated list" collector form.
+//
+// Representative collector: opensearch (this file). ListDomainNames returns
+// every domain in a single call, so — unlike the paginator and manual-token
+// forms — there is no per-page list pagination to stream. The streaming
+// guarantees this form must keep are therefore:
+//
+//   - per-item enrich streaming: the first domain is pushed as soon as its own
+//     DescribeDomain call finishes, without waiting for later domains.
+//   - failure isolation: a single domain whose DescribeDomain fails is skipped
+//     (describeDomain returns nil and streamDomains continues) so one failure
+//     neither panics nor aborts the rest of the region. This locks the bug fix
+//     in commit 65e81d7.
+//
+// No other AWS collector currently shares this un-paginated form; opensearch is
+// the sole representative.
+package opensearch
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/opensearch"
+	"github.com/aws/aws-sdk-go-v2/service/opensearch/types"
+)
+
+// fakeOpenSearchClient is a deterministic opensearchAPI stand-in. ListDomainNames
+// returns every domain at once; DescribeDomain echoes a status back per domain
+// but can be made to block after a configured number of calls (per-item enrich
+// streaming) or to fail for one named domain (failure isolation).
+type fakeOpenSearchClient struct {
+	domains []types.DomainInfo
+
+	blockDescribeAfter int // block DescribeDomain after this many calls
+	unblockDescribe    chan struct{}
+
+	failDescribeName string // DescribeDomain returns an error for this domain name
+
+	mu            sync.Mutex
+	describeCalls int
+}
+
+func (f *fakeOpenSearchClient) ListDomainNames(context.Context, *opensearch.ListDomainNamesInput, ...func(*opensearch.Options)) (*opensearch.ListDomainNamesOutput, error) {
+	return &opensearch.ListDomainNamesOutput{DomainNames: f.domains}, nil
+}
+
+func (f *fakeOpenSearchClient) DescribeDomain(ctx context.Context, input *opensearch.DescribeDomainInput, _ ...func(*opensearch.Options)) (*opensearch.DescribeDomainOutput, error) {
+	f.mu.Lock()
+	f.describeCalls++
+	call := f.describeCalls
+	f.mu.Unlock()
+
+	if f.blockDescribeAfter > 0 && call > f.blockDescribeAfter && f.unblockDescribe != nil {
+		select {
+		case <-f.unblockDescribe:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	name := aws.ToString(input.DomainName)
+	if f.failDescribeName != "" && name == f.failDescribeName {
+		return nil, fmt.Errorf("describe failed for %s", name)
+	}
+
+	return &opensearch.DescribeDomainOutput{
+		DomainStatus: &types.DomainStatus{
+			DomainName: input.DomainName,
+			DomainId:   aws.String(name),
+		},
+	}, nil
+}
+
+// per-item enrich streaming: the first domain is pushed once its own
+// DescribeDomain returns, without waiting for later domains. The second
+// DescribeDomain call is blocked, so a build-slice-then-push regression would
+// never deliver the first result.
+func TestStreamDomainsPushesFirstResultBeforeAllDomainsFinish(t *testing.T) {
+	unblock := make(chan struct{})
+	client := &fakeOpenSearchClient{
+		domains:            makeDomains(5),
+		blockDescribeAfter: 1,
+		unblockDescribe:    unblock,
+	}
+	res := make(chan any, len(client.domains))
+	done := make(chan error, 1)
+
+	go func() {
+		done <- streamDomains(context.Background(), client, res)
+	}()
+
+	detail := receiveFirstDomain(t, res)
+	if detail.DomainStatus == nil {
+		t.Fatal("domain status is nil")
+	}
+	close(unblock)
+
+	if err := <-done; err != nil {
+		t.Fatalf("streamDomains returned error: %v", err)
+	}
+	if got := 1 + len(res); got != len(client.domains) {
+		t.Fatalf("streamed domain count = %d, want %d", got, len(client.domains))
+	}
+}
+
+// failure isolation: one domain whose DescribeDomain fails is skipped without
+// panicking, and the remaining domains still stream. Removing the nil guard in
+// streamDomains makes this dereference a nil DescribeDomainOutput and panic,
+// regressing commit 65e81d7.
+func TestStreamDomainsSkipsFailedDescribeWithoutPanic(t *testing.T) {
+	client := &fakeOpenSearchClient{
+		domains:          makeDomains(3),
+		failDescribeName: "domain-1", // the middle domain's DescribeDomain fails
+	}
+	res := make(chan any, len(client.domains))
+
+	if err := streamDomains(context.Background(), client, res); err != nil {
+		t.Fatalf("streamDomains returned error: %v", err)
+	}
+	close(res)
+
+	var got []DomainDetail
+	for d := range res {
+		detail, ok := d.(DomainDetail)
+		if !ok {
+			t.Fatalf("got %T, want DomainDetail", d)
+		}
+		got = append(got, detail)
+	}
+	if len(got) != 2 {
+		t.Fatalf("streamed domain count = %d, want 2 (one DescribeDomain failure skipped)", len(got))
+	}
+	for _, d := range got {
+		if aws.ToString(d.DomainStatus.DomainName) == "domain-1" {
+			t.Fatal("failed domain leaked into results")
+		}
+	}
+}
+
+func receiveFirstDomain(t *testing.T, res <-chan any) DomainDetail {
+	t.Helper()
+	select {
+	case got := <-res:
+		detail, ok := got.(DomainDetail)
+		if !ok {
+			t.Fatalf("got %T, want DomainDetail", got)
+		}
+		return detail
+	case <-time.After(time.Second):
+		t.Fatal("collector did not stream first result before processing all domains")
+	}
+	return DomainDetail{}
+}
+
+func makeDomains(count int) []types.DomainInfo {
+	domains := make([]types.DomainInfo, 0, count)
+	for i := 0; i < count; i++ {
+		domains = append(domains, types.DomainInfo{
+			DomainName: aws.String(fmt.Sprintf("domain-%d", i)),
+		})
+	}
+	return domains
+}

--- a/collector/aws/collector/rds/rds.go
+++ b/collector/aws/collector/rds/rds.go
@@ -59,27 +59,33 @@ type InstanceDetail struct {
 	VPCSecurityGroups []ec2Type.SecurityGroup
 }
 
-// GetInstanceDetail streams each RDS instance detail as its security
-// group lookups finish, to avoid the 30s consumer idle timeout in
-// core-sdk schema/platform.go.
+// GetInstanceDetail streams each RDS instance detail as the
+// DescribeDBInstances pagination yields it and its security group lookups
+// finish, avoiding the 30s consumer idle timeout in core-sdk
+// schema/platform.go.
 func GetInstanceDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	services := service.(*collector.Services)
 	rdsClient := services.RDS
 	ec2Client := services.EC2
 
-	instances, err := describeInstances(ctx, rdsClient)
-	if err != nil {
-		return err
-	}
-
-	for _, instance := range instances {
-		res <- InstanceDetail{
-			DBInstance:        instance,
-			DBSecurityGroups:  describeDBSecurityGroups(ctx, rdsClient, instance.DBSecurityGroups),
-			VPCSecurityGroups: describeVPCSecurityGroups(ctx, ec2Client, instance.VpcSecurityGroups),
+	input := &rds.DescribeDBInstancesInput{}
+	for {
+		output, err := rdsClient.DescribeDBInstances(ctx, input)
+		if err != nil {
+			return err
 		}
+		for _, instance := range output.DBInstances {
+			res <- InstanceDetail{
+				DBInstance:        instance,
+				DBSecurityGroups:  describeDBSecurityGroups(ctx, rdsClient, instance.DBSecurityGroups),
+				VPCSecurityGroups: describeVPCSecurityGroups(ctx, ec2Client, instance.VpcSecurityGroups),
+			}
+		}
+		if output.Marker == nil {
+			return nil
+		}
+		input.Marker = output.Marker
 	}
-	return nil
 }
 
 func describeVPCSecurityGroups(ctx context.Context, ec2Client *ec2.Client, groups []rdsType.VpcSecurityGroupMembership) (vpcSecurityGroups []ec2Type.SecurityGroup) {
@@ -130,24 +136,4 @@ func describeDBSecurityGroups(ctx context.Context, c *rds.Client, groups []types
 		}
 	}
 	return dBSecurityGroups
-}
-
-// Obtain the database instance information
-func describeInstances(ctx context.Context, c *rds.Client) (instances []types.DBInstance, err error) {
-	input := &rds.DescribeDBInstancesInput{}
-	output, err := c.DescribeDBInstances(ctx, input)
-	if err != nil {
-		return nil, err
-	}
-	instances = append(instances, output.DBInstances...)
-	for output.Marker != nil {
-		input.Marker = output.Marker
-		output, err = c.DescribeDBInstances(ctx, input)
-		if err != nil {
-			return nil, err
-		}
-		instances = append(instances, output.DBInstances...)
-	}
-
-	return instances, nil
 }

--- a/collector/aws/collector/rds/rds.go
+++ b/collector/aws/collector/rds/rds.go
@@ -59,37 +59,27 @@ type InstanceDetail struct {
 	VPCSecurityGroups []ec2Type.SecurityGroup
 }
 
+// GetInstanceDetail streams each RDS instance detail as its security
+// group lookups finish, to avoid the 30s consumer idle timeout in
+// core-sdk schema/platform.go.
 func GetInstanceDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	services := service.(*collector.Services)
 	rdsClient := services.RDS
 	ec2Client := services.EC2
 
-	instanceDetails, err := describeInstanceDetails(ctx, rdsClient, ec2Client)
+	instances, err := describeInstances(ctx, rdsClient)
 	if err != nil {
 		return err
 	}
 
-	for _, instanceDetail := range instanceDetails {
-		res <- instanceDetail
-	}
-	return nil
-}
-
-func describeInstanceDetails(ctx context.Context, rdsClient *rds.Client, ec2Client *ec2.Client) (instanceDetails []InstanceDetail, err error) {
-
-	instances, err := describeInstances(ctx, rdsClient)
-	if err != nil {
-		return nil, err
-	}
 	for _, instance := range instances {
-		instanceDetails = append(instanceDetails, InstanceDetail{
+		res <- InstanceDetail{
 			DBInstance:        instance,
 			DBSecurityGroups:  describeDBSecurityGroups(ctx, rdsClient, instance.DBSecurityGroups),
 			VPCSecurityGroups: describeVPCSecurityGroups(ctx, ec2Client, instance.VpcSecurityGroups),
-		})
+		}
 	}
-
-	return instanceDetails, nil
+	return nil
 }
 
 func describeVPCSecurityGroups(ctx context.Context, ec2Client *ec2.Client, groups []rdsType.VpcSecurityGroupMembership) (vpcSecurityGroups []ec2Type.SecurityGroup) {

--- a/collector/aws/collector/route53/domain.go
+++ b/collector/aws/collector/route53/domain.go
@@ -161,36 +161,27 @@ type DomainDetail struct {
 	WhoIsServer *string
 }
 
+// GetTheDomainDetail streams each Route53 domain detail as its
+// GetDomainDetail call completes, avoiding the 30s consumer idle timeout
+// in core-sdk schema/platform.go when an account has many domains.
 func GetTheDomainDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 
 	client := service.(*collector.Services).Route53Domains
 
-	domainDetails, err := describeDomainDetails(ctx, client)
+	domains, err := listDomains(ctx, client)
 	if err != nil {
-		log.CtxLogger(ctx).Warn("describeDomainDetails error", zap.Error(err))
+		log.CtxLogger(ctx).Warn("listDomains error", zap.Error(err))
 		return err
 	}
 
-	for _, domainDetail := range domainDetails {
-		res <- domainDetail
+	for _, domain := range domains {
+		res <- TheDomainDetail{
+			DomainSummary: domain,
+			DomainDetail:  getDomainDetail(ctx, client, domain),
+		}
 	}
 
 	return nil
-}
-
-func describeDomainDetails(ctx context.Context, c *route53domains.Client) (domainDetails []TheDomainDetail, err error) {
-	domains, err := listDomains(ctx, c)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("listDomains error", zap.Error(err))
-		return nil, err
-	}
-	for _, domain := range domains {
-		domainDetails = append(domainDetails, TheDomainDetail{
-			DomainSummary: domain,
-			DomainDetail:  getDomainDetail(ctx, c, domain),
-		})
-	}
-	return domainDetails, nil
 }
 
 func listDomains(ctx context.Context, c *route53domains.Client) (domains []types.DomainSummary, err error) {

--- a/collector/aws/collector/route53/domain.go
+++ b/collector/aws/collector/route53/domain.go
@@ -161,49 +161,32 @@ type DomainDetail struct {
 	WhoIsServer *string
 }
 
-// GetTheDomainDetail streams each Route53 domain detail as its
-// GetDomainDetail call completes, avoiding the 30s consumer idle timeout
-// in core-sdk schema/platform.go when an account has many domains.
+// GetTheDomainDetail streams each Route53 domain as the ListDomains
+// pagination yields it and its GetDomainDetail call completes, avoiding
+// the 30s consumer idle timeout in core-sdk schema/platform.go when an
+// account has many domains.
 func GetTheDomainDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 
 	client := service.(*collector.Services).Route53Domains
 
-	domains, err := listDomains(ctx, client)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("listDomains error", zap.Error(err))
-		return err
-	}
-
-	for _, domain := range domains {
-		res <- TheDomainDetail{
-			DomainSummary: domain,
-			DomainDetail:  getDomainDetail(ctx, client, domain),
-		}
-	}
-
-	return nil
-}
-
-func listDomains(ctx context.Context, c *route53domains.Client) (domains []types.DomainSummary, err error) {
-
 	input := &route53domains.ListDomainsInput{}
-	output, err := c.ListDomains(ctx, input)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("listDomains error", zap.Error(err))
-		return nil, err
-	}
-	domains = append(domains, output.Domains...)
-	for output.NextPageMarker != nil {
-		input.Marker = output.NextPageMarker
-		output, err = c.ListDomains(ctx, input)
+	for {
+		output, err := client.ListDomains(ctx, input)
 		if err != nil {
 			log.CtxLogger(ctx).Warn("listDomains error", zap.Error(err))
-			return nil, err
+			return err
 		}
-		domains = append(domains, output.Domains...)
+		for _, domain := range output.Domains {
+			res <- TheDomainDetail{
+				DomainSummary: domain,
+				DomainDetail:  getDomainDetail(ctx, client, domain),
+			}
+		}
+		if output.NextPageMarker == nil {
+			return nil
+		}
+		input.Marker = output.NextPageMarker
 	}
-
-	return domains, nil
 }
 
 func getDomainDetail(ctx context.Context, c *route53domains.Client, domain types.DomainSummary) DomainDetail {

--- a/collector/aws/collector/route53/resourcerecordset.go
+++ b/collector/aws/collector/route53/resourcerecordset.go
@@ -50,27 +50,32 @@ type RecordSetDetailDetail struct {
 	ResourceRecordSets []types.ResourceRecordSet
 }
 
-// GetResourceRecordSetDetail streams each hosted-zone record set as the
-// per-zone ListResourceRecordSets paginator completes, avoiding the 30s
-// consumer idle timeout in core-sdk schema/platform.go when an account
-// has many hosted zones.
+// GetResourceRecordSetDetail streams each hosted zone as the
+// ListHostedZones pagination yields it; the per-zone
+// ListResourceRecordSets calls then stream their record sets. This
+// incremental push avoids the 30s consumer idle timeout in core-sdk
+// schema/platform.go when an account has many hosted zones.
 func GetResourceRecordSetDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).Route53
 
-	hostedZones, err := listHostedZones(ctx, client)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("listHostedZones error", zap.Error(err))
-		return err
-	}
-
-	for _, hostedZone := range hostedZones {
-		res <- RecordSetDetailDetail{
-			HostedZone:         hostedZone,
-			ResourceRecordSets: listResourceRecordSets(ctx, client, hostedZone),
+	input := &route53.ListHostedZonesInput{}
+	for {
+		output, err := client.ListHostedZones(ctx, input)
+		if err != nil {
+			log.CtxLogger(ctx).Warn("listHostedZones error", zap.Error(err))
+			return err
 		}
+		for _, hostedZone := range output.HostedZones {
+			res <- RecordSetDetailDetail{
+				HostedZone:         hostedZone,
+				ResourceRecordSets: listResourceRecordSets(ctx, client, hostedZone),
+			}
+		}
+		if !output.IsTruncated {
+			return nil
+		}
+		input.Marker = output.NextMarker
 	}
-
-	return nil
 }
 
 func listResourceRecordSets(ctx context.Context, c *route53.Client, hostZone types.HostedZone) (resourceRecordSets []types.ResourceRecordSet) {
@@ -89,24 +94,4 @@ func listResourceRecordSets(ctx context.Context, c *route53.Client, hostZone typ
 	}
 
 	return resourceRecordSets
-}
-
-func listHostedZones(ctx context.Context, c *route53.Client) (hostedZones []types.HostedZone, err error) {
-	input := &route53.ListHostedZonesInput{}
-	output, err := c.ListHostedZones(ctx, input)
-	if err != nil {
-		return nil, err
-	}
-	hostedZones = append(hostedZones, output.HostedZones...)
-	for output.IsTruncated {
-		input.Marker = output.NextMarker
-		output, err = c.ListHostedZones(ctx, input)
-		if err != nil {
-			log.CtxLogger(ctx).Warn("listHostedZones error", zap.Error(err))
-			return nil, err
-		}
-		hostedZones = append(hostedZones, output.HostedZones...)
-	}
-
-	return hostedZones, nil
 }

--- a/collector/aws/collector/route53/resourcerecordset.go
+++ b/collector/aws/collector/route53/resourcerecordset.go
@@ -50,38 +50,27 @@ type RecordSetDetailDetail struct {
 	ResourceRecordSets []types.ResourceRecordSet
 }
 
+// GetResourceRecordSetDetail streams each hosted-zone record set as the
+// per-zone ListResourceRecordSets paginator completes, avoiding the 30s
+// consumer idle timeout in core-sdk schema/platform.go when an account
+// has many hosted zones.
 func GetResourceRecordSetDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).Route53
 
-	domainRRDetails, err := describeDomainRRDetails(ctx, client)
+	hostedZones, err := listHostedZones(ctx, client)
 	if err != nil {
-		log.CtxLogger(ctx).Warn("describeDomainRRDetails error", zap.Error(err))
+		log.CtxLogger(ctx).Warn("listHostedZones error", zap.Error(err))
 		return err
 	}
 
-	for _, domainRRDetail := range domainRRDetails {
-		res <- domainRRDetail
+	for _, hostedZone := range hostedZones {
+		res <- RecordSetDetailDetail{
+			HostedZone:         hostedZone,
+			ResourceRecordSets: listResourceRecordSets(ctx, client, hostedZone),
+		}
 	}
 
 	return nil
-}
-
-func describeDomainRRDetails(ctx context.Context, c *route53.Client) (domainRRDetails []RecordSetDetailDetail, err error) {
-
-	hostedZones, err := listHostedZones(ctx, c)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("listHostedZones error", zap.Error(err))
-		return nil, err
-	}
-
-	for _, hostedZone := range hostedZones {
-		domainRRDetails = append(domainRRDetails, RecordSetDetailDetail{
-			HostedZone:         hostedZone,
-			ResourceRecordSets: listResourceRecordSets(ctx, c, hostedZone),
-		})
-	}
-
-	return domainRRDetails, nil
 }
 
 func listResourceRecordSets(ctx context.Context, c *route53.Client, hostZone types.HostedZone) (resourceRecordSets []types.ResourceRecordSet) {

--- a/collector/aws/collector/s3/bucket.go
+++ b/collector/aws/collector/s3/bucket.go
@@ -58,36 +58,28 @@ type BucketDetail struct {
 	LoggingEnabled *types.LoggingEnabled
 }
 
+// GetBucketDetail streams each S3 bucket detail as its three secondary
+// calls (Policy / Versioning / Logging) complete, avoiding the 30s
+// consumer idle timeout in core-sdk schema/platform.go when an account
+// has many buckets.
 func GetBucketDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).S3
 
-	bucketDetails, err := describeBucketDetails(ctx, client)
+	buckets, err := listBuckets(ctx, client)
 	if err != nil {
-		log.CtxLogger(ctx).Warn("describeBucketDetails error", zap.Error(err))
+		log.CtxLogger(ctx).Warn("listBuckets error", zap.Error(err))
 		return err
 	}
 
-	for _, bucketDetail := range bucketDetails {
-		res <- bucketDetail
+	for _, bucket := range buckets {
+		res <- BucketDetail{
+			Bucket:         bucket,
+			Policy:         getBucketPolicy(ctx, client, bucket),
+			Versioning:     getVersioning(ctx, client, bucket),
+			LoggingEnabled: getLoggingEnabled(ctx, client, bucket),
+		}
 	}
 	return nil
-}
-
-func describeBucketDetails(ctx context.Context, c *s3.Client) (bucketDetails []BucketDetail, err error) {
-	buckets, err := listBuckets(ctx, c)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("listBuckets error", zap.Error(err))
-		return nil, err
-	}
-	for _, bucket := range buckets {
-		bucketDetails = append(bucketDetails, BucketDetail{
-			Bucket:         bucket,
-			Policy:         getBucketPolicy(ctx, c, bucket),
-			Versioning:     getVersioning(ctx, c, bucket),
-			LoggingEnabled: getLoggingEnabled(ctx, c, bucket),
-		})
-	}
-	return bucketDetails, nil
 }
 
 func getLoggingEnabled(ctx context.Context, c *s3.Client, bucket types.Bucket) *types.LoggingEnabled {

--- a/collector/aws/collector/s3/bucket.go
+++ b/collector/aws/collector/s3/bucket.go
@@ -58,28 +58,36 @@ type BucketDetail struct {
 	LoggingEnabled *types.LoggingEnabled
 }
 
-// GetBucketDetail streams each S3 bucket detail as its three secondary
-// calls (Policy / Versioning / Logging) complete, avoiding the 30s
-// consumer idle timeout in core-sdk schema/platform.go when an account
-// has many buckets.
+// GetBucketDetail streams each S3 bucket as the ListBuckets pagination
+// yields it and its three secondary calls (Policy / Versioning / Logging)
+// complete, avoiding the 30s consumer idle timeout in core-sdk
+// schema/platform.go when an account has many buckets.
 func GetBucketDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).S3
 
-	buckets, err := listBuckets(ctx, client)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("listBuckets error", zap.Error(err))
-		return err
+	bucketRegion := client.Options().Region
+	input := &s3.ListBucketsInput{
+		BucketRegion: &bucketRegion,
 	}
-
-	for _, bucket := range buckets {
-		res <- BucketDetail{
-			Bucket:         bucket,
-			Policy:         getBucketPolicy(ctx, client, bucket),
-			Versioning:     getVersioning(ctx, client, bucket),
-			LoggingEnabled: getLoggingEnabled(ctx, client, bucket),
+	for {
+		output, err := client.ListBuckets(ctx, input)
+		if err != nil {
+			log.CtxLogger(ctx).Warn("listBuckets error", zap.Error(err))
+			return err
 		}
+		for _, bucket := range output.Buckets {
+			res <- BucketDetail{
+				Bucket:         bucket,
+				Policy:         getBucketPolicy(ctx, client, bucket),
+				Versioning:     getVersioning(ctx, client, bucket),
+				LoggingEnabled: getLoggingEnabled(ctx, client, bucket),
+			}
+		}
+		if output.ContinuationToken == nil {
+			return nil
+		}
+		input.ContinuationToken = output.ContinuationToken
 	}
-	return nil
 }
 
 func getLoggingEnabled(ctx context.Context, c *s3.Client, bucket types.Bucket) *types.LoggingEnabled {
@@ -119,28 +127,4 @@ func getBucketPolicy(ctx context.Context, c *s3.Client, bucket types.Bucket) (po
 		return nil
 	}
 	return policy
-}
-
-func listBuckets(ctx context.Context, c *s3.Client) (buckets []types.Bucket, err error) {
-	bucketRegion := c.Options().Region
-	listBucketsInput := &s3.ListBucketsInput{
-		BucketRegion: &bucketRegion,
-	}
-	listBucketsOutput, err := c.ListBuckets(ctx, listBucketsInput)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("listBuckets error", zap.Error(err))
-		return nil, err
-	}
-	buckets = append(buckets, listBucketsOutput.Buckets...)
-	for listBucketsOutput.ContinuationToken != nil {
-		listBucketsInput.ContinuationToken = listBucketsOutput.ContinuationToken
-		listBucketsOutput, err = c.ListBuckets(ctx, listBucketsInput)
-		if err != nil {
-			log.CtxLogger(ctx).Warn("listBuckets error", zap.Error(err))
-			return nil, err
-		}
-		buckets = append(buckets, listBucketsOutput.Buckets...)
-	}
-
-	return buckets, nil
 }

--- a/collector/aws/collector/secretsmanager/secret.go
+++ b/collector/aws/collector/secretsmanager/secret.go
@@ -50,21 +50,23 @@ type SecretDetail struct {
 }
 
 // GetSecretDetail fetches the details for all Secrets Manager secrets.
-// Each detail is pushed to res as its per-secret GetResourcePolicy
-// finishes; do not refactor this into a build-slice-then-push pattern,
-// as that would risk the 30s consumer idle timeout in core-sdk
-// schema/platform.go (see commit 8295d1b).
+// The ListSecrets pagination streams per page and each secret is pushed
+// to res as its GetResourcePolicy finishes; do not refactor back to a
+// build-slice-then-push pattern, as that would risk the 30s consumer idle
+// timeout in core-sdk schema/platform.go (see commit 8295d1b).
 func GetSecretDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).SecretsManager
 
-	secrets, err := listSecrets(ctx, client)
-	if err != nil {
-		log.CtxLogger(ctx).Error("failed to list secrets", zap.Error(err))
-		return err
-	}
-
-	for _, secret := range secrets {
-		res <- describeSecretDetail(ctx, client, secret)
+	paginator := secretsmanager.NewListSecretsPaginator(client, &secretsmanager.ListSecretsInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			log.CtxLogger(ctx).Error("failed to list secrets", zap.Error(err))
+			return err
+		}
+		for _, secret := range page.SecretList {
+			res <- describeSecretDetail(ctx, client, secret)
+		}
 	}
 
 	return nil
@@ -83,20 +85,6 @@ func describeSecretDetail(ctx context.Context, client *secretsmanager.Client, se
 		Secret: secret,
 		Policy: policy,
 	}
-}
-
-// listSecrets retrieves all Secrets Manager secrets.
-func listSecrets(ctx context.Context, c *secretsmanager.Client) ([]types.SecretListEntry, error) {
-	var secrets []types.SecretListEntry
-	paginator := secretsmanager.NewListSecretsPaginator(c, &secretsmanager.ListSecretsInput{})
-	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, err
-		}
-		secrets = append(secrets, page.SecretList...)
-	}
-	return secrets, nil
 }
 
 // getResourcePolicy retrieves the resource policy for a secret.

--- a/collector/aws/collector/secretsmanager/secret.go
+++ b/collector/aws/collector/secretsmanager/secret.go
@@ -50,6 +50,10 @@ type SecretDetail struct {
 }
 
 // GetSecretDetail fetches the details for all Secrets Manager secrets.
+// Each detail is pushed to res as its per-secret GetResourcePolicy
+// finishes; do not refactor this into a build-slice-then-push pattern,
+// as that would risk the 30s consumer idle timeout in core-sdk
+// schema/platform.go (see commit 8295d1b).
 func GetSecretDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).SecretsManager
 

--- a/collector/aws/collector/sns/topic.go
+++ b/collector/aws/collector/sns/topic.go
@@ -52,24 +52,25 @@ type SNSTopicDetail struct {
 	Tags          []types.Tag
 }
 
-// GetSNSTopicDetail fetches the details for all SNS topics. Each
-// detail is pushed to res as its per-topic GetAttributes /
-// ListSubscriptions / ListTags calls finish; do not refactor this
-// into a build-slice-then-push pattern, as that would risk the 30s
-// consumer idle timeout in core-sdk schema/platform.go (see commit
+// GetSNSTopicDetail fetches the details for all SNS topics. The ListTopics
+// pagination streams per page and each topic is pushed to res as its
+// GetAttributes / ListSubscriptions / ListTags calls finish; do not
+// refactor back to a build-slice-then-push pattern, as that would risk the
+// 30s consumer idle timeout in core-sdk schema/platform.go (see commit
 // 8295d1b).
 func GetSNSTopicDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).SNS
 
-	topics, err := listTopics(ctx, client)
-	if err != nil {
-		log.CtxLogger(ctx).Error("failed to list SNS topics", zap.Error(err))
-		return err
-	}
-
-	for _, topic := range topics {
-		detail := describeSNSTopicDetail(ctx, client, topic)
-		res <- detail
+	paginator := sns.NewListTopicsPaginator(client, &sns.ListTopicsInput{})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			log.CtxLogger(ctx).Error("failed to list SNS topics", zap.Error(err))
+			return err
+		}
+		for _, topic := range page.Topics {
+			res <- describeSNSTopicDetail(ctx, client, topic)
+		}
 	}
 
 	return nil
@@ -118,20 +119,6 @@ func describeSNSTopicDetail(ctx context.Context, client *sns.Client, topic types
 		Subscriptions: subscriptions,
 		Tags:          tags,
 	}
-}
-
-// listTopics retrieves all SNS topics.
-func listTopics(ctx context.Context, c *sns.Client) ([]types.Topic, error) {
-	var topics []types.Topic
-	paginator := sns.NewListTopicsPaginator(c, &sns.ListTopicsInput{})
-	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, err
-		}
-		topics = append(topics, page.Topics...)
-	}
-	return topics, nil
 }
 
 // getTopicAttributes retrieves attributes for a topic.

--- a/collector/aws/collector/sns/topic.go
+++ b/collector/aws/collector/sns/topic.go
@@ -52,7 +52,12 @@ type SNSTopicDetail struct {
 	Tags          []types.Tag
 }
 
-// GetSNSTopicDetail fetches the details for all SNS topics.
+// GetSNSTopicDetail fetches the details for all SNS topics. Each
+// detail is pushed to res as its per-topic GetAttributes /
+// ListSubscriptions / ListTags calls finish; do not refactor this
+// into a build-slice-then-push pattern, as that would risk the 30s
+// consumer idle timeout in core-sdk schema/platform.go (see commit
+// 8295d1b).
 func GetSNSTopicDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).SNS
 

--- a/collector/aws/collector/sqs/queue.go
+++ b/collector/aws/collector/sqs/queue.go
@@ -54,23 +54,42 @@ type SQSQueueDetail struct {
 	Tags       map[string]string
 }
 
-// GetSQSQueueDetail fetches the details for all SQS queues. Each detail
-// is pushed to res as its per-queue GetAttributes / ListQueueTags calls
-// finish; do not refactor this into a build-slice-then-push pattern, as
-// that would risk the 30s consumer idle timeout in core-sdk
-// schema/platform.go (see commit 8295d1b).
+// GetSQSQueueDetail fetches the details for all SQS queues. The ListQueues
+// pagination streams per page and each queue is pushed to res as its
+// GetAttributes / ListQueueTags calls finish; do not refactor back to a
+// build-slice-then-push pattern, as that would risk the 30s consumer idle
+// timeout in core-sdk schema/platform.go (see commit 8295d1b).
 func GetSQSQueueDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).SQS
 
-	queues, err := listQueues(ctx, client)
-	if err != nil {
-		log.CtxLogger(ctx).Error("failed to list SQS queues", zap.Error(err))
-		return err
+	region := client.Options().Region
+	maxResults := int32(1000)
+	input := &sqs.ListQueuesInput{
+		MaxResults: &maxResults,
 	}
 
-	for _, queue := range queues {
-		queueDetail := describeSQSQueueDetail(ctx, client, queue)
-		res <- queueDetail
+	paginator := sqs.NewListQueuesPaginator(client, input)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			log.CtxLogger(ctx).Error("failed to list SQS queues", zap.Error(err))
+			return err
+		}
+		for _, queueUrl := range page.QueueUrls {
+			// Extract queue name from URL
+			queueName := queueUrl
+			if len(queueUrl) > 0 {
+				parts := strings.Split(queueUrl, "/")
+				if len(parts) > 0 {
+					queueName = parts[len(parts)-1]
+				}
+			}
+			res <- describeSQSQueueDetail(ctx, client, SQSQueueDetail{
+				Url:    queueUrl,
+				Name:   queueName,
+				Region: region,
+			})
+		}
 	}
 
 	return nil
@@ -109,46 +128,6 @@ func describeSQSQueueDetail(ctx context.Context, client *sqs.Client, queue SQSQu
 	queue.Tags = tags
 
 	return &queue
-}
-
-// listQueues retrieves all SQS queues.
-func listQueues(ctx context.Context, c *sqs.Client) ([]SQSQueueDetail, error) {
-	var queues []SQSQueueDetail
-
-	// Get the region from the client
-	region := c.Options().Region
-
-	maxResults := int32(1000)
-	input := &sqs.ListQueuesInput{
-		MaxResults: &maxResults,
-	}
-
-	paginator := sqs.NewListQueuesPaginator(c, input)
-	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, queueUrl := range page.QueueUrls {
-			// Extract queue name from URL
-			queueName := queueUrl
-			if len(queueUrl) > 0 {
-				parts := strings.Split(queueUrl, "/")
-				if len(parts) > 0 {
-					queueName = parts[len(parts)-1]
-				}
-			}
-
-			queues = append(queues, SQSQueueDetail{
-				Url:    queueUrl,
-				Name:   queueName,
-				Region: region,
-			})
-		}
-	}
-
-	return queues, nil
 }
 
 // getQueueAttributes retrieves attributes for a queue.

--- a/collector/aws/collector/sqs/queue.go
+++ b/collector/aws/collector/sqs/queue.go
@@ -54,7 +54,11 @@ type SQSQueueDetail struct {
 	Tags       map[string]string
 }
 
-// GetSQSQueueDetail fetches the details for all SQS queues.
+// GetSQSQueueDetail fetches the details for all SQS queues. Each detail
+// is pushed to res as its per-queue GetAttributes / ListQueueTags calls
+// finish; do not refactor this into a build-slice-then-push pattern, as
+// that would risk the 30s consumer idle timeout in core-sdk
+// schema/platform.go (see commit 8295d1b).
 func GetSQSQueueDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).SQS
 

--- a/collector/aws/collector/wafv2/webalc.go
+++ b/collector/aws/collector/wafv2/webalc.go
@@ -52,24 +52,34 @@ type WebACLDetail struct {
 	Scope types.Scope
 }
 
-// GetWebACLDetail streams each Web ACL detail as its per-ACL GetWebACL
-// call completes, iterating over both CLOUDFRONT and REGIONAL scopes.
-// Streaming avoids the 30s consumer idle timeout in core-sdk
-// schema/platform.go when an account has many Web ACLs.
+// GetWebACLDetail streams each Web ACL as the per-scope ListWebACLs
+// pagination yields it and its GetWebACL call completes, iterating over
+// both CLOUDFRONT and REGIONAL scopes. Streaming avoids the 30s consumer
+// idle timeout in core-sdk schema/platform.go when an account has many
+// Web ACLs.
 func GetWebACLDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).WAFv2
 
 	for _, scope := range types.Scope.Values("") {
-		webACLSummaryList, err := listWebACLs(ctx, client, scope)
-		if err != nil {
-			log.CtxLogger(ctx).Warn("listWebACLs error", zap.Error(err), zap.String("scope", string(scope)))
-			continue
+		input := &wafv2.ListWebACLsInput{
+			Scope: scope,
 		}
-		for _, webACLSummary := range webACLSummaryList {
-			res <- WebACLDetail{
-				WebACL: getWebACL(ctx, client, webACLSummary.Id, webACLSummary.Name, scope),
-				Scope:  scope,
+		for {
+			output, err := client.ListWebACLs(ctx, input)
+			if err != nil {
+				log.CtxLogger(ctx).Warn("listWebACLs error", zap.Error(err), zap.String("scope", string(scope)))
+				break
 			}
+			for _, webACLSummary := range output.WebACLs {
+				res <- WebACLDetail{
+					WebACL: getWebACL(ctx, client, webACLSummary.Id, webACLSummary.Name, scope),
+					Scope:  scope,
+				}
+			}
+			if output.NextMarker == nil {
+				break
+			}
+			input.NextMarker = output.NextMarker
 		}
 	}
 
@@ -89,27 +99,4 @@ func getWebACL(ctx context.Context, c *wafv2.Client, id *string, name *string, s
 	}
 
 	return *output.WebACL
-}
-
-func listWebACLs(ctx context.Context, c *wafv2.Client, scope types.Scope) (webACLSummaryList []types.WebACLSummary, err error) {
-	input := &wafv2.ListWebACLsInput{
-		Scope: scope,
-	}
-	output, err := c.ListWebACLs(ctx, input)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("listWebACLs error", zap.Error(err))
-		return nil, err
-	}
-	webACLSummaryList = append(webACLSummaryList, output.WebACLs...)
-	for output.NextMarker != nil {
-		input.NextMarker = output.NextMarker
-		output, err = c.ListWebACLs(ctx, input)
-		if err != nil {
-			log.CtxLogger(ctx).Warn("listWebACLs error", zap.Error(err))
-			return nil, err
-		}
-		webACLSummaryList = append(webACLSummaryList, output.WebACLs...)
-	}
-
-	return webACLSummaryList, nil
 }

--- a/collector/aws/collector/wafv2/webalc.go
+++ b/collector/aws/collector/wafv2/webalc.go
@@ -52,37 +52,28 @@ type WebACLDetail struct {
 	Scope types.Scope
 }
 
+// GetWebACLDetail streams each Web ACL detail as its per-ACL GetWebACL
+// call completes, iterating over both CLOUDFRONT and REGIONAL scopes.
+// Streaming avoids the 30s consumer idle timeout in core-sdk
+// schema/platform.go when an account has many Web ACLs.
 func GetWebACLDetail(ctx context.Context, service schema.ServiceInterface, res chan<- any) error {
 	client := service.(*collector.Services).WAFv2
-	webACLDetails, err := describeWebACLDetails(ctx, client)
-	if err != nil {
-		log.CtxLogger(ctx).Warn("describeWebACLDetails error", zap.Error(err))
-		return err
-	}
-	for _, webACLDetail := range webACLDetails {
-		res <- webACLDetail
+
+	for _, scope := range types.Scope.Values("") {
+		webACLSummaryList, err := listWebACLs(ctx, client, scope)
+		if err != nil {
+			log.CtxLogger(ctx).Warn("listWebACLs error", zap.Error(err), zap.String("scope", string(scope)))
+			continue
+		}
+		for _, webACLSummary := range webACLSummaryList {
+			res <- WebACLDetail{
+				WebACL: getWebACL(ctx, client, webACLSummary.Id, webACLSummary.Name, scope),
+				Scope:  scope,
+			}
+		}
 	}
 
 	return nil
-}
-
-func describeWebACLDetails(ctx context.Context, c *wafv2.Client) (webACLDetails []WebACLDetail, err error) {
-
-	for _, scope := range types.Scope.Values("") {
-		webACLSummaryList, err := listWebACLs(ctx, c, scope)
-		if err != nil {
-			log.CtxLogger(ctx).Warn("listWebACLs error", zap.Error(err))
-			return nil, err
-		}
-		for _, webACLSummary := range webACLSummaryList {
-			webACLDetails = append(webACLDetails, WebACLDetail{
-				WebACL: getWebACL(ctx, c, webACLSummary.Id, webACLSummary.Name, scope),
-				Scope:  scope,
-			})
-		}
-	}
-
-	return webACLDetails, nil
 }
 
 func getWebACL(ctx context.Context, c *wafv2.Client, id *string, name *string, scope types.Scope) types.WebACL {

--- a/collector/core-sdk/schema/platform.go
+++ b/collector/core-sdk/schema/platform.go
@@ -358,7 +358,44 @@ func (p *Platform) handleResource(ctx context.Context, account CloudAccount, res
 		// for region chan
 		regionCh := make(chan interface{}, constant.DefaultPageSize)
 
-		// Consumer
+		// Producer slot pre-acquire — MUST happen before starting Consumer.
+		//
+		// The Consumer goroutine below has a 30s idle timer (`time.After`) that
+		// begins ticking the moment the goroutine runs. If we acquired the
+		// per-region semaphore AFTER starting Consumer and the region's slot
+		// was already saturated (10 active producers per region), the blocking
+		// `limiter <- struct{}{}` could exceed 30s. Consumer would then fire
+		// the timeout branch, close(regionCh), and any subsequent Producer
+		// push would panic with "send on closed channel" — yielding 0 inserts
+		// for this (account, region, ResourceType) and causing all previously
+		// known resources in that tuple to be soft-deleted on the next merge
+		// pass (since the framework treats an empty collector result as a
+		// signal that those resources no longer exist).
+		//
+		// This was observed in prod on 2026-05-21 after the streaming refactor
+		// (commit 5f3db2f) let us-east-1 EC2 (181 instances) hold a slot for
+		// ~240s, knocking out ELB / ELB Listener / ElastiCache / EFS in the
+		// same region (boto3 confirmed 115 / 150 / 20 / 7 live there).
+		loopRegionWait.Add(1)
+		// Create timeout context based on the input context to preserve account information
+		regionCtx, cancel := context.WithTimeout(ctx, 240*time.Second)
+		// Add region-specific information to the context
+		regionCtx = context.WithValue(regionCtx, constant.RegionId, region)
+		regionCtx = context.WithValue(regionCtx, constant.TraceId, version)
+		// Get rate limiter for this region
+		limiter := p.getRegionLimiter(region)
+
+		// Acquire semaphore. Time the wait so it can be attached to the
+		// "send on closed channel" warn below if and only if slot contention
+		// actually caused data loss — keeping the log noise to real-loss
+		// events rather than every saturated slot acquisition (which, with
+		// the pre-acquire ordering above, no longer threatens data integrity
+		// on its own).
+		limiterWaitStart := time.Now()
+		limiter <- struct{}{}
+		limiterWait := time.Since(limiterWaitStart)
+
+		// Consumer (30s idle timer only begins ticking now, after the slot is acquired)
 		go func() {
 			defer func() {
 				// Panic recovery mechanism to prevent program crash
@@ -403,17 +440,7 @@ func (p *Platform) handleResource(ctx context.Context, account CloudAccount, res
 			}
 		}()
 
-		// Producer
-		loopRegionWait.Add(1)
-		// Create timeout context based on the input context to preserve account information
-		regionCtx, cancel := context.WithTimeout(ctx, 240*time.Second)
-		// Get rate limiter for this region
-		limiter := p.getRegionLimiter(region)
-		// Acquire semaphore
-		limiter <- struct{}{}
-		// Add region-specific information to the context
-		regionCtx = context.WithValue(regionCtx, constant.RegionId, region)
-		regionCtx = context.WithValue(regionCtx, constant.TraceId, version)
+		// Producer (slot already acquired above; this goroutine releases it on defer)
 		go func(regionCtx context.Context, regionService ServiceInterface) {
 			defer func() {
 				cancel()
@@ -424,7 +451,13 @@ func (p *Platform) handleResource(ctx context.Context, account CloudAccount, res
 				if r := recover(); r != nil {
 					errMsg := fmt.Sprintf("%v", r)
 					if strings.Contains(errMsg, "send on closed channel") {
-						log.CtxLogger(ctx).Warn(fmt.Sprintf("Timeout, more than %d seconds !!!", constant.TimeOut))
+						// Data loss event: Consumer closed regionCh while Producer was still pushing.
+						// Attach the prior limiter wait so we can tell at a glance whether this loss
+						// was caused by slot contention (large wait) or by the Producer's own API
+						// latency being > 30s between pushes (small wait).
+						log.CtxLogger(ctx).Warn(fmt.Sprintf(
+							"Timeout, more than %d seconds !!! (RegionLimiter wait was %v)",
+							constant.TimeOut, limiterWait))
 					} else {
 						errmsg := fmt.Sprintf("Code:[%s] Recovered from panic of unknown type: %s", UnknownError, r)
 						log.CtxLogger(ctx).Error(errmsg)


### PR DESCRIPTION
<!--
Please keep PRs small and fixed in scope.
Add tests for new features.
-->
Thank you for your contribution to CloudRec!

### What About:
* [ ] Server (`java`)
* [x] Collector (`go`)
* [ ] Rule (`opa`)

### Description:
## Summary

This PR improves AWS collector reliability for large accounts and slow regions by changing the collection flow from batch-then-push to incremental streaming.

Previously, several AWS collectors could spend more than 30 seconds listing or enriching resources before sending the first result to the core framework. Because the framework consumer has a 30-second idle timeout, this could close the result channel early and cause empty or incomplete collection results.

## What Changed

- Stream AWS resource details as soon as each item, page, or batch is ready instead of accumulating full result sets before pushing.
- Extend the streaming pattern across AWS collectors that previously used batch-then-push collection.
- Stream primary resource pagination page by page for collectors where listing itself can be slow.
- Update ECS cluster collection to push results per describe batch instead of accumulating all clusters first.
- Fix a framework-level race by acquiring the per-region producer slot before starting the consumer, so queue wait time does not count against the consumer idle timeout.
- Add regression tests covering representative streaming forms: manual pagination, SDK paginator, ARN batch describe, and unpaginated list + per-item enrichment.

## Test Plan

- Added AWS collector streaming regression tests.
- Verified the implementation preserves the existing resource data model while reducing idle-timeout risk.
