### PR TITLE
[Fix] Clear stale address/resource_name when a re-collected asset longer has them

### DIFF
--- a/app/dao/src/main/resources/mapper/CloudResourceInstanceMapper.xml
+++ b/app/dao/src/main/resources/mapper/CloudResourceInstanceMapper.xml
@@ -176,15 +176,14 @@
             <if test="resourceType != null">
                 resource_type = #{resourceType,jdbcType=VARCHAR},
             </if>
-            <if test="address != null">
-                address = #{address,jdbcType=VARCHAR},
-            </if>
+            <!-- address/resource_name mirror the latest collector snapshot: write unconditionally
+                 (like deleted_at) so a value that disappears upstream, e.g. a released public IP,
+                 is cleared instead of leaving a stale value behind -->
+            address = #{address,jdbcType=VARCHAR},
             <if test="resourceId != null">
                 resource_id = #{resourceId,jdbcType=VARCHAR},
             </if>
-            <if test="resourceName != null">
-                resource_name = #{resourceName,jdbcType=VARCHAR},
-            </if>
+            resource_name = #{resourceName,jdbcType=VARCHAR},
             <if test="version != null">
                 version = #{version,jdbcType=VARCHAR},
             </if>


### PR DESCRIPTION

<!--
Please keep PRs small and fixed in scope.
Add tests for new features.
-->
Thank you for your contribution to CloudRec!

### What About:
* [x] Server (`java`)
* [ ] Collector (`go`)
* [ ] Rule (`opa`)

### Description:


updateByPrimaryKeySelective guarded every column with <if test="... != null">, but the collector push is a full snapshot: when a derived field such as the public IP behind RowField.Address disappears upstream, the collector omits it (omitempty), the server receives null, and the selective guard silently skips the column. The instance JSON is overwritten with the new snapshot while the address column keeps the released IP forever - the value->empty transition is unrepresentable.

Write address and resource_name unconditionally, following the existing deleted_at pattern in the same statement (already unconditional so pre-delete tags can be cleared). The sole caller of this statement is the collector snapshot persistence path (SaveResourceServiceImpl.saveOrUpdateData), which always populates the PO from the pushed payload, so no other write path is affected. Stale rows self-heal on the next collection cycle.

