### PR TITLE
Fix/oss gcp credential and panic

### DIFF
--- a/client/src/components/CloudCredentialEditor/index.tsx
+++ b/client/src/components/CloudCredentialEditor/index.tsx
@@ -22,7 +22,7 @@ const CloudCredentialEditor: React.FC<CloudCredentialEditorProps> = ({
   };
   const handleJsonChange = (jsonValue: string) => {
     const validJsonValue = jsonValue?.trim() || '{}';
-    onChange?.({ credentialsJson: validJsonValue } as CloudAccountCredentials);
+    onChange?.({ credential: validJsonValue } as CloudAccountCredentials);
   };
 
   if (accountId && !visible) {
@@ -44,9 +44,9 @@ const CloudCredentialEditor: React.FC<CloudCredentialEditorProps> = ({
   if (type === 'json') {
     return (
       <ProFormText
-        name="credentialsJson"
+        name="credential"
         label="GCP KEY"
-        initialValue={value?.credentialsJson || '{}'}
+        initialValue={value?.credential || '{}'}
         rules={[{
           required: true,
           validator: async (_: any, value: string) => {
@@ -62,7 +62,7 @@ const CloudCredentialEditor: React.FC<CloudCredentialEditorProps> = ({
         }]}
       >
         <JSONEditor
-          value={value?.credentialsJson || '{}'}
+          value={value?.credential || '{}'}
           onChange={handleJsonChange}
           editorStyle={{ height: '240px' }}
           editorKey="CREDENTIALS_JSON_EDITOR"

--- a/client/src/components/CloudCredentialEditor/types.ts
+++ b/client/src/components/CloudCredentialEditor/types.ts
@@ -31,7 +31,7 @@ export interface CloudAccountCredentials {
   evsEndpoint?: string;
   vpcEndpoint?: string;
   obsEndpoint?: string;
-  credentialsJson?: string;
+  credential?: string;
 }
 
 export interface CloudAccountFormData {

--- a/client/src/pages/CloudAccount/AccountList/components/EditModalForm.tsx
+++ b/client/src/pages/CloudAccount/AccountList/components/EditModalForm.tsx
@@ -55,10 +55,10 @@ const EditDrawerForm: React.FC<IEditFormProps> = (props) => {
     if (!platformConfig) return;
 
     if (platformConfig.type === 'json') {
-      const jsonStr = value.credentialsJson || '{}';
+      const jsonStr = value.credential || '{}';
       setJsonValue(jsonStr);
       form.setFieldsValue({
-        credentials: { credentialsJson: jsonStr }
+        credentials: { credential: jsonStr }
       });
     } else {
       const currentCredentials = form.getFieldValue('credentials') || {};
@@ -111,7 +111,7 @@ const EditDrawerForm: React.FC<IEditFormProps> = (props) => {
     // The voucher information is processed only when it is visible in the voucher editor
     if (extendEditorVisible) {
       if (platformConfig.type === 'json') {
-        postBody.credentialsObj = { credentialsJson: credentials?.credentialsJson || jsonValue };
+        postBody.credentialsObj = { credential: credentials?.credential || jsonValue };
       } else {
         const credentialsData: Partial<CloudAccountCredentials> = { ...(credentials || {}) };
         platformConfig.fields.forEach((field: { name: string }) => {
@@ -156,8 +156,8 @@ const EditDrawerForm: React.FC<IEditFormProps> = (props) => {
         enableInverseSelection: rest.enableInverseSelection || false
       };
 
-      if (platform && PLATFORM_CONFIGS[platform]?.type === 'json' && credentialMap?.credentialsJson) {
-        setJsonValue(credentialMap.credentialsJson);
+      if (platform && PLATFORM_CONFIGS[platform]?.type === 'json' && credentialMap?.credential) {
+        setJsonValue(credentialMap.credential);
       }
 
       form.setFieldsValue(formData);

--- a/client/src/pages/CloudAccount/AccountList/config/platformConfig.tsx
+++ b/client/src/pages/CloudAccount/AccountList/config/platformConfig.tsx
@@ -64,7 +64,7 @@ export const PLATFORM_CONFIGS: Record<string, PlatformConfig> = {
   'GCP': {
     type: 'json',
     fields: [
-      { name: 'credentialsJson', label: 'GCP KEY', required: true }
+      { name: 'credential', label: 'GCP KEY', required: true }
     ]
   },
   'ALI_CLOUD_PRIVATE': {

--- a/collector/gcp/collector/cloudresourcemanager/organization.go
+++ b/collector/gcp/collector/cloudresourcemanager/organization.go
@@ -22,9 +22,6 @@ import (
 	"cloud.google.com/go/resourcemanager/apiv3"
 	"cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
 	"context"
-	"errors"
-	"fmt"
-	"google.golang.org/api/iterator"
 
 	"github.com/core-sdk/log"
 	"github.com/cloudrec/gcp/collector"
@@ -42,9 +39,6 @@ func GetOrganizationResource() schema.Resource {
 			svc := service.(*collector.Services).OrganizationsClient
 
 			for organization, err := range SearchOrganizations(ctx, svc) {
-				if errors.Is(err, iterator.Done) {
-					return fmt.Errorf("get 0 organization")
-				}
 				if err != nil {
 					log.CtxLogger(ctx).Warn("SearchOrganizations error", zap.Error(err))
 					return err
@@ -70,10 +64,31 @@ type OrganizationDetail struct {
 	IAMPolicy    *iampb.Policy
 }
 
+// SearchOrganizations lists the organizations visible to the caller.
+//
+// The API returns an empty result rather than an error when the caller has no
+// organization-level permission, which would otherwise make Organization, User
+// AccessBinding, Access Policy and Perimeter all collect zero resources without
+// leaving a trace in the log. Warn once in that case so "no permission" can be
+// told apart from "no such resource".
 func SearchOrganizations(ctx context.Context, svc *resourcemanager.OrganizationsClient) iter.Seq2[*resourcemanagerpb.Organization, error] {
-
-	a := svc.SearchOrganizations(ctx, &resourcemanagerpb.SearchOrganizationsRequest{}).All()
-	return a
+	return func(yield func(*resourcemanagerpb.Organization, error) bool) {
+		found := false
+		for organization, err := range svc.SearchOrganizations(ctx, &resourcemanagerpb.SearchOrganizationsRequest{}).All() {
+			if err == nil {
+				found = true
+			}
+			if !yield(organization, err) {
+				return
+			}
+		}
+		if !found {
+			log.CtxLogger(ctx).Warn("SearchOrganizations returned no organization, " +
+				"the service account is most likely missing organization-level permission " +
+				"(resourcemanager.organizations.get); Organization, User AccessBinding, " +
+				"Access Policy and Perimeter will all collect nothing")
+		}
+	}
 }
 
 func getOrgIAMPolicy(ctx context.Context, svc *resourcemanager.OrganizationsClient, OrgName string) *iampb.Policy {

--- a/collector/gcp/collector/computeengine/address.go
+++ b/collector/gcp/collector/computeengine/address.go
@@ -20,7 +20,6 @@ import (
 	"github.com/core-sdk/log"
 	"github.com/core-sdk/schema"
 	"context"
-	"fmt"
 	"github.com/cloudrec/gcp/collector"
 	"github.com/cloudrec/gcp/utils"
 	"go.uber.org/zap"
@@ -39,21 +38,32 @@ func GetAddressResource() schema.Resource {
 
 			for _, project := range projects {
 				projectId := project.ProjectId
-				loadBalanceDict := LoadBalanceDict{}
-				loadBalanceDict.getAllDict(ctx, svc, projectId)
 
+				// List the addresses before building the load balancer dictionary.
+				// getAllDict costs eight AggregatedList calls per project, and in an
+				// org-wide scan the overwhelming majority of projects hold no address
+				// at all, so paying that up front is what pushes the whole resource
+				// type past its context deadline.
+				addresses := make([]*compute.Address, 0)
 				resp := svc.Addresses.AggregatedList(projectId).MaxResults(100)
 				if err := resp.Pages(ctx, func(page *compute.AddressAggregatedList) error {
 					for _, item := range page.Items {
-						for _, address := range item.Addresses {
-							detail := buildAddressDetail(address, &loadBalanceDict)
-							res <- detail
-						}
+						addresses = append(addresses, item.Addresses...)
 					}
 					return nil
 				}); err != nil {
 					log.CtxLogger(ctx).Warn("GetAddressResource error", zap.Error(err))
 					continue
+				}
+				if len(addresses) == 0 {
+					continue
+				}
+
+				loadBalanceDict := LoadBalanceDict{}
+				loadBalanceDict.getAllDict(ctx, svc, projectId)
+
+				for _, address := range addresses {
+					res <- buildAddressDetail(ctx, address, &loadBalanceDict)
 				}
 			}
 
@@ -138,6 +148,7 @@ func (d *LoadBalanceDict) getAllForwardingRules() {
 		}
 		return nil
 	}); _err != nil {
+		log.CtxLogger(ctx).Warn("getAllForwardingRules error", zap.Error(_err))
 		return
 	}
 }
@@ -157,6 +168,7 @@ func (d *LoadBalanceDict) getAllTargetHttpProxies() {
 		}
 		return nil
 	}); _err != nil {
+		log.CtxLogger(ctx).Warn("getAllTargetHttpProxies error", zap.Error(_err))
 		return
 	}
 }
@@ -176,6 +188,7 @@ func (d *LoadBalanceDict) getAllTargetHttpsProxies() {
 		}
 		return nil
 	}); _err != nil {
+		log.CtxLogger(ctx).Warn("getAllTargetHttpsProxies error", zap.Error(_err))
 		return
 	}
 }
@@ -195,6 +208,7 @@ func (d *LoadBalanceDict) getAllTargetTcpProxies() {
 		}
 		return nil
 	}); _err != nil {
+		log.CtxLogger(ctx).Warn("getAllTargetTcpProxies error", zap.Error(_err))
 		return
 	}
 }
@@ -212,6 +226,7 @@ func (d *LoadBalanceDict) getAllTargetSslProxies() {
 		}
 		return nil
 	}); _err != nil {
+		log.CtxLogger(ctx).Warn("getAllTargetSslProxies error", zap.Error(_err))
 		return
 	}
 }
@@ -231,6 +246,7 @@ func (d *LoadBalanceDict) getAllUrlMaps() {
 		}
 		return nil
 	}); _err != nil {
+		log.CtxLogger(ctx).Warn("getAllUrlMaps error", zap.Error(_err))
 		return
 	}
 }
@@ -250,6 +266,7 @@ func (d *LoadBalanceDict) getAllBackendServices() {
 		}
 		return nil
 	}); _err != nil {
+		log.CtxLogger(ctx).Warn("getAllBackendServices error", zap.Error(_err))
 		return
 	}
 }
@@ -269,11 +286,12 @@ func (d *LoadBalanceDict) getAllSecurityPolicies() {
 		}
 		return nil
 	}); _err != nil {
+		log.CtxLogger(ctx).Warn("getAllSecurityPolicies error", zap.Error(_err))
 		return
 	}
 }
 
-func buildAddressDetail(address *compute.Address, loadBalanceDict *LoadBalanceDict) (detail *AddressDetail) {
+func buildAddressDetail(ctx context.Context, address *compute.Address, loadBalanceDict *LoadBalanceDict) (detail *AddressDetail) {
 
 	detail = &AddressDetail{
 		Address:            address,
@@ -293,7 +311,15 @@ func buildAddressDetail(address *compute.Address, loadBalanceDict *LoadBalanceDi
 		rId := utils.GetResourceID(user)
 		switch rType {
 		case "forwardingRules":
+			// Every lookup below can miss: the dictionary is assembled from a
+			// separate set of AggregatedList calls, any of which may have failed
+			// or been truncated. A map miss yields a nil pointer, so it must be
+			// checked before use rather than dereferenced.
 			forwardingRule := loadBalanceDict.forwardingRulesDict[rId]
+			if forwardingRule == nil {
+				log.CtxLogger(ctx).Debug("forwardingRule missing from dict", zap.String("forwardingRule", rId))
+				continue
+			}
 			forwardingRuleTargetType := utils.GetResourceType(forwardingRule.Target)
 			forwardingRuleTargetId := utils.GetResourceID(forwardingRule.Target)
 
@@ -302,55 +328,72 @@ func buildAddressDetail(address *compute.Address, loadBalanceDict *LoadBalanceDi
 			// 1. Application Load Balancers
 			// [Traffic] --> [Forwarding Rule] --> [Target HTTP/HTTPS proxy] --> [URL Map] --> [Backend Service]
 			// todo: there are too many place to set service T^T
-			case "targetHttpProxies":
-				fmt.Println("No Support")
-				continue
-			case "targetHttpsProxies":
-				fmt.Println("No Support")
+			case "targetHttpProxies", "targetHttpsProxies":
+				log.CtxLogger(ctx).Debug("application load balancer target is not supported yet",
+					zap.String("targetType", forwardingRuleTargetType))
 				continue
 
 			// 2 Proxy Network Load Balancers
 			//	[Traffic] --> [Forwarding Rule] --> [Target TCP/SSL proxy] --> [Backend Service]
 			case "targetTcpProxies":
 				tmpTargetTcpProxy := loadBalanceDict.targetTcpProxiesDict[forwardingRuleTargetId]
-				tmpBackendService := loadBalanceDict.backendServiceDict[utils.GetResourceID(tmpTargetTcpProxy.Service)]
-				tmpSecurityPolicy := loadBalanceDict.securityPolicyDict[utils.GetResourceID(tmpBackendService.SecurityPolicy)]
+				if tmpTargetTcpProxy == nil {
+					log.CtxLogger(ctx).Debug("targetTcpProxy missing from dict", zap.String("targetTcpProxy", forwardingRuleTargetId))
+					continue
+				}
 
 				detail.ForwardingRules = append(detail.ForwardingRules, forwardingRule)
 				detail.TargetTcpProxies = append(detail.TargetTcpProxies, tmpTargetTcpProxy)
-				detail.BackendServices = append(detail.BackendServices, tmpBackendService)
-				detail.SecurityPolicies = append(detail.SecurityPolicies, tmpSecurityPolicy)
+				appendBackendService(ctx, detail, loadBalanceDict, utils.GetResourceID(tmpTargetTcpProxy.Service))
 			case "targetSslProxies":
 				tmpTargetSslProxy := loadBalanceDict.targetSslProxiesDict[forwardingRuleTargetId]
-				tmpBackendService := loadBalanceDict.backendServiceDict[utils.GetResourceID(tmpTargetSslProxy.Service)]
-				tmpSecurityPolicy := loadBalanceDict.securityPolicyDict[utils.GetResourceID(tmpBackendService.SecurityPolicy)]
+				if tmpTargetSslProxy == nil {
+					log.CtxLogger(ctx).Debug("targetSslProxy missing from dict", zap.String("targetSslProxy", forwardingRuleTargetId))
+					continue
+				}
 
 				detail.ForwardingRules = append(detail.ForwardingRules, forwardingRule)
 				detail.TargetSslProxies = append(detail.TargetSslProxies, tmpTargetSslProxy)
-				detail.BackendServices = append(detail.BackendServices, tmpBackendService)
-				detail.SecurityPolicies = append(detail.SecurityPolicies, tmpSecurityPolicy)
+				appendBackendService(ctx, detail, loadBalanceDict, utils.GetResourceID(tmpTargetSslProxy.Service))
 
 			// 3. Passthrough Network Load Balancers
 			// [Traffic] --> [Forwarding Rule] --> [Backend Service]
 			case "backendServices":
-				tmpBackendService := loadBalanceDict.backendServiceDict[forwardingRuleTargetId]
-				tmpSecurityPolicy := loadBalanceDict.securityPolicyDict[utils.GetResourceID(tmpBackendService.SecurityPolicy)]
-
 				detail.ForwardingRules = append(detail.ForwardingRules, forwardingRule)
-				detail.BackendServices = append(detail.BackendServices, tmpBackendService)
-				detail.SecurityPolicies = append(detail.SecurityPolicies, tmpSecurityPolicy)
+				appendBackendService(ctx, detail, loadBalanceDict, forwardingRuleTargetId)
 			// 4. Other use case
 			default:
-				fmt.Println("Unknown ForwardingRule Target Type")
+				log.CtxLogger(ctx).Debug("unknown forwardingRule target type", zap.String("targetType", forwardingRuleTargetType))
 				continue
 			}
 
 		default:
-			fmt.Println("Unknown Address User Type")
+			log.CtxLogger(ctx).Debug("unknown address user type", zap.String("userType", rType))
 			continue
 		}
 
 	}
 
 	return
+}
+
+// appendBackendService resolves a backend service and its Cloud Armor policy out
+// of the dictionary and appends whatever could be resolved to detail. Entries the
+// dictionary cannot resolve are skipped rather than appended as nil, which would
+// otherwise put a null into the persisted resource JSON.
+func appendBackendService(ctx context.Context, detail *AddressDetail, loadBalanceDict *LoadBalanceDict, backendServiceId string) {
+	backendService := loadBalanceDict.backendServiceDict[backendServiceId]
+	if backendService == nil {
+		log.CtxLogger(ctx).Debug("backendService missing from dict", zap.String("backendService", backendServiceId))
+		return
+	}
+	detail.BackendServices = append(detail.BackendServices, backendService)
+
+	// A backend service with no Cloud Armor policy attached is perfectly normal,
+	// so an unresolved policy is not worth reporting.
+	securityPolicy := loadBalanceDict.securityPolicyDict[utils.GetResourceID(backendService.SecurityPolicy)]
+	if securityPolicy == nil {
+		return
+	}
+	detail.SecurityPolicies = append(detail.SecurityPolicies, securityPolicy)
 }

--- a/collector/gcp/collector/services.go
+++ b/collector/gcp/collector/services.go
@@ -157,7 +157,7 @@ func (s *Services) InitServices(cloudAccountParam schema.CloudAccountParam) (err
 			log.GetWLogger().Warn(fmt.Sprintf("Failed to create vpc client: %v", err))
 		}
 		s.VpcAccessService = svc
-	case AccessPolicy, Perimeter:
+	case AccessPolicy, Perimeter, UserAccessBinding:
 		ACMSvc, err := accesscontextmanager.NewClient(ctx, clientOption)
 		if err != nil {
 			log.GetWLogger().Warn(fmt.Sprintf("Failed to create access context manager client: %v", err))

--- a/collector/gcp/collector/services.go
+++ b/collector/gcp/collector/services.go
@@ -103,7 +103,9 @@ func (s *Services) InitServices(cloudAccountParam schema.CloudAccountParam) (err
 		if err != nil {
 			log.CtxLogger(ctx).Warn("SearchProjects error", zap.Error(err))
 			s.Projects = append(s.Projects, &resourcemanagerpb.Project{ProjectId: param.ProjectId})
-			//return err
+			// project is nil on error; appending it would make every resource
+			// collector nil-dereference project.ProjectId later on.
+			continue
 		}
 		s.Projects = append(s.Projects, project)
 	}


### PR DESCRIPTION
<!--
Please keep PRs small and fixed in scope.
Add tests for new features.
-->
Thank you for your contribution to CloudRec!

### What About:
* [x] Server (`java`)
* [x] Collector (`go`)
* [ ] Rule (`opa`)

### Description:
## What

Five independent fixes for the GCP collector, found while running it
against a GCP organization rather than a single project.

- **GCP accounts saved from the web UI never worked.** The form submitted
  `credentialsObj` as `{"credentialsJson": ...}`, but `GcpCredential` only
  declares a `credential` field — Gson left it null, so the collector got
  an empty credential, fell back to Application Default Credentials and
  failed every resource with `could not find default credentials`.
  Renamed the web-side field to match the server contract.

- **`User AccessBinding` panicked on every run.** `InitServices` had no
  case for it, leaving `AccessContextManager` and `OrganizationsClient`
  nil for `SearchOrganizations` to dereference. Added it to the
  `AccessPolicy`/`Perimeter` case, which already builds exactly those two.

- **`Address` could not finish a scan.** It built the load balancer
  dictionary — eight `AggregatedList` calls — for every project *before*
  checking whether that project has any address, i.e. ~9 serial calls per
  project regardless of whether there is anything to enrich. Now lists
  addresses first and only enriches when there is something to enrich.
  Also nil-checks the six dictionary lookups that were dereferenced
  directly, and logs the eight `getAllDict` failures that were silently
  swallowed — either fix alone would just trade the timeout for a panic.

- **`SearchProjects` appended a nil project on error**, because the
  guarding `return err` was commented out. Every collector iterates that
  slice and reads `project.ProjectId`.

- **Four resource types collected nothing, silently.**
  `SearchOrganizations` returns an empty result rather than an error when
  the caller lacks organization-level permission, so `Organization`,
  `User AccessBinding`, `Access Policy` and `Perimeter` all came back
  empty with nothing in the log to distinguish "no permission" from "no
  such resource". Now warns once from the shared helper.

## Note

Existing GCP accounts created through the web UI need their key
re-entered once, since the stored credential uses the old field name.
They could not collect before this change, so nothing is lost.

## Verification

Verified end to end against a live GCP organization: credentials now save
and round-trip through the UI, `User AccessBinding` no longer panics,
`Address` completes instead of hitting its context deadline, and the
organization-scoped resource types return data once the service account
has org-level permission.
